### PR TITLE
fix: privacy policy link, cookie banner, and Netlify contact form

### DIFF
--- a/NIS2.html
+++ b/NIS2.html
@@ -605,6 +605,7 @@ function Nis2App() {
       <Nis2FAQ />
       <FinalCTA />
       <Footer />
+      <CookieBanner />
     </>
   );
 }

--- a/ai-w-praktyce.html
+++ b/ai-w-praktyce.html
@@ -287,6 +287,7 @@ function PracticeApp() {
       </section>
 
       <Footer />
+      <CookieBanner />
     </>
   );
 }

--- a/home-sections.jsx
+++ b/home-sections.jsx
@@ -381,21 +381,31 @@ const Contact = () => (
             Pn–Pt 9:00–17:00 · CET
           </div>
         </div>
-        <form className="card" style={{ padding: 32 }} onSubmit={(e) => { e.preventDefault(); alert("Demo formularz — wiadomość wysłana"); }}>
+        <form
+          className="card"
+          style={{ padding: 32 }}
+          name="contact"
+          method="POST"
+          action="/success.html"
+          data-netlify="true"
+          netlify-honeypot="bot-field"
+        >
+          <input type="hidden" name="form-name" value="contact" />
+          <input type="hidden" name="bot-field" />
           <h3 style={{ marginBottom: 24 }}>📬 Formularz kontaktowy</h3>
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <FormField label="Imię i nazwisko" required placeholder="Jan Kowalski" />
-            <FormField label="Adres e-mail" required type="email" placeholder="jan@firma.pl" />
-            <FormField label="Numer telefonu" type="tel" placeholder="+48 123 456 789" />
-            <FormField label="Nazwa firmy" placeholder="Firma sp. z o.o." />
-            <FormSelect label="Czego dotyczy zapytanie?" options={["Doradztwo AI dla firm", "Korepetycje AI", "Automatyzacja marketingu", "Agenci AI / automatyzacja", "Spersonalizowane asystenty", "Wdrożenia NIS2", "Strona internetowa", "Inne"]} />
-            <FormTextarea label="Opis projektu / dodatkowe informacje" required placeholder="Opisz swoje potrzeby, oczekiwania i cele projektu. Im więcej szczegółów, tym lepiej dopasuję ofertę." />
+            <FormField label="Imię i nazwisko" name="name" required placeholder="Jan Kowalski" />
+            <FormField label="Adres e-mail" name="email" required type="email" placeholder="jan@firma.pl" />
+            <FormField label="Numer telefonu" name="phone" type="tel" placeholder="+48 123 456 789" />
+            <FormField label="Nazwa firmy" name="company" placeholder="Firma sp. z o.o." />
+            <FormSelect label="Czego dotyczy zapytanie?" name="subject" options={["Doradztwo AI dla firm", "Korepetycje AI", "Automatyzacja marketingu", "Agenci AI / automatyzacja", "Spersonalizowane asystenty", "Wdrożenia NIS2", "Strona internetowa", "Inne"]} />
+            <FormTextarea label="Opis projektu / dodatkowe informacje" name="message" required placeholder="Opisz swoje potrzeby, oczekiwania i cele projektu. Im więcej szczegółów, tym lepiej dopasuję ofertę." />
             <label style={{ display: "flex", gap: 10, fontSize: "0.85rem", color: "var(--fg-muted)", lineHeight: 1.5 }}>
-              <input type="checkbox" required style={{ marginTop: 4 }} />
-              <span>Wyrażam zgodę na przetwarzanie danych zgodnie z <a href="#">Polityką Prywatności</a>. *</span>
+              <input type="checkbox" name="privacy_consent" required style={{ marginTop: 4 }} />
+              <span>Wyrażam zgodę na przetwarzanie danych zgodnie z <a href="privacy-policy.html">Polityką Prywatności</a>. *</span>
             </label>
             <label style={{ display: "flex", gap: 10, fontSize: "0.85rem", color: "var(--fg-muted)", lineHeight: 1.5 }}>
-              <input type="checkbox" style={{ marginTop: 4 }} />
+              <input type="checkbox" name="marketing_consent" style={{ marginTop: 4 }} />
               <span>Wyrażam zgodę na otrzymywanie informacji marketingowych o usługach BrightMind AI Solutions.</span>
             </label>
             <button type="submit" className="btn btn-primary" style={{ justifyContent: "center", marginTop: 8 }}>Wyślij wiadomość 🚀</button>
@@ -406,10 +416,10 @@ const Contact = () => (
   </section>
 );
 
-const FormField = ({ label, required, type = "text", placeholder }) => (
+const FormField = ({ label, required, type = "text", placeholder, name }) => (
   <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
     <span style={{ fontSize: "0.85rem", color: "var(--fg-muted)" }}>{label} {required && <span style={{ color: "var(--accent)" }}>*</span>}</span>
-    <input type={type} placeholder={placeholder} required={required} style={{
+    <input type={type} name={name} placeholder={placeholder} required={required} style={{
       background: "var(--bg)",
       border: "1px solid var(--border)",
       borderRadius: "var(--radius)",
@@ -421,10 +431,10 @@ const FormField = ({ label, required, type = "text", placeholder }) => (
   </label>
 );
 
-const FormSelect = ({ label, options }) => (
+const FormSelect = ({ label, options, name }) => (
   <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
     <span style={{ fontSize: "0.85rem", color: "var(--fg-muted)" }}>{label}</span>
-    <select style={{
+    <select name={name} style={{
       background: "var(--bg)",
       border: "1px solid var(--border)",
       borderRadius: "var(--radius)",
@@ -438,10 +448,10 @@ const FormSelect = ({ label, options }) => (
   </label>
 );
 
-const FormTextarea = ({ label, required, placeholder }) => (
+const FormTextarea = ({ label, required, placeholder, name }) => (
   <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
     <span style={{ fontSize: "0.85rem", color: "var(--fg-muted)" }}>{label} {required && <span style={{ color: "var(--accent)" }}>*</span>}</span>
-    <textarea placeholder={placeholder} required={required} rows={4} style={{
+    <textarea name={name} placeholder={placeholder} required={required} rows={4} style={{
       background: "var(--bg)",
       border: "1px solid var(--border)",
       borderRadius: "var(--radius)",

--- a/index.html
+++ b/index.html
@@ -323,6 +323,19 @@
     <!-- End Meta Pixel Code -->
 </head>
 <body itemscope itemtype="https://schema.org/WebPage">
+<!-- Hidden form for Netlify Forms build-time detection -->
+<form name="contact" netlify netlify-honeypot="bot-field" hidden>
+  <input name="bot-field" />
+  <input name="name" />
+  <input name="email" type="email" />
+  <input name="phone" type="tel" />
+  <input name="company" />
+  <select name="subject"></select>
+  <textarea name="message"></textarea>
+  <input type="checkbox" name="privacy_consent" />
+  <input type="checkbox" name="marketing_consent" />
+</form>
+
 <div id="app"></div>
 
 <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" crossorigin="anonymous"></script>
@@ -348,6 +361,7 @@ function HomeApp() {
       <FAQ />
       <Contact />
       <Footer />
+      <CookieBanner />
     </>
   );
 }

--- a/o-mnie.html
+++ b/o-mnie.html
@@ -177,6 +177,7 @@ function AboutApp() {
       </section>
 
       <Footer />
+      <CookieBanner />
     </>
   );
 }

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -165,6 +165,7 @@ function PrivacyApp() {
       </section>
 
       <Footer />
+      <CookieBanner />
     </>
   );
 }

--- a/shared.jsx
+++ b/shared.jsx
@@ -110,4 +110,82 @@ const Icon = ({ name, size = 20 }) => {
   return <svg {...props}>{paths[name] || paths.check}</svg>;
 };
 
-Object.assign(window, { Nav, Footer, Icon });
+const CookieBanner = () => {
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!localStorage.getItem('cookie_consent')) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('cookie_consent', 'accepted');
+    setVisible(false);
+  };
+
+  const decline = () => {
+    localStorage.setItem('cookie_consent', 'declined');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div style={{
+      position: "fixed",
+      bottom: 0,
+      left: 0,
+      right: 0,
+      background: "var(--bg-elev)",
+      borderTop: "1px solid var(--border)",
+      padding: "16px 24px",
+      zIndex: 9999,
+      display: "flex",
+      alignItems: "center",
+      gap: 16,
+      flexWrap: "wrap",
+    }}>
+      <p style={{ margin: 0, fontSize: "0.875rem", color: "var(--fg-muted)", flex: 1, minWidth: 240 }}>
+        Używamy plików cookie (w tym Facebook Pixel) w celu analizy ruchu i poprawy jakości usług.
+        Więcej informacji znajdziesz w naszej{" "}
+        <a href="privacy-policy.html" style={{ color: "var(--accent)" }}>Polityce prywatności</a>.
+      </p>
+      <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+        <button
+          onClick={decline}
+          style={{
+            background: "transparent",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            padding: "8px 18px",
+            color: "var(--fg-muted)",
+            fontFamily: "inherit",
+            fontSize: "0.875rem",
+            cursor: "pointer",
+          }}
+        >
+          Odrzuć
+        </button>
+        <button
+          onClick={accept}
+          style={{
+            background: "var(--accent)",
+            border: "1px solid var(--accent)",
+            borderRadius: "var(--radius)",
+            padding: "8px 18px",
+            color: "#fff",
+            fontFamily: "inherit",
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          Akceptuję
+        </button>
+      </div>
+    </div>
+  );
+};
+
+Object.assign(window, { Nav, Footer, Icon, CookieBanner });

--- a/success.html
+++ b/success.html
@@ -70,6 +70,7 @@ function SuccessApp() {
         </div>
       </section>
       <Footer />
+      <CookieBanner />
     </>
   );
 }


### PR DESCRIPTION
- Fix broken privacy policy href in contact form checkbox (was "#")
- Add CookieBanner component to shared.jsx with localStorage persistence, accept/decline buttons, and link to privacy policy page; added to all pages
- Fix Netlify contact form: add data-netlify, name/method/action attributes, hidden form-name input, name attrs on all fields, honeypot spam protection, and static hidden form in index.html for Netlify build-time detection

https://claude.ai/code/session_01ASg6iQHmLm2LuPfYeWhJQT