### PR TITLE
fix: privacy policy link, cookie banner, Netlify form + YouTube icon

### DIFF
--- a/shared.jsx
+++ b/shared.jsx
@@ -69,12 +69,23 @@ const Footer = () => (
             <li>Patryk Gliński</li>
             <li><a href="mailto:kontakt@brightmind-solutions.com">kontakt@brightmind-solutions.com</a></li>
             <li><a href="tel:+48730152161">+48 730 152 161</a></li>
-            <li style={{ marginTop: 12 }}>
+            <li style={{ marginTop: 16 }}>
               <a
                 href="https://www.youtube.com/@Neural_Update"
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ display: "inline-flex", alignItems: "center", gap: 8, color: "var(--fg-muted)" }}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "8px 14px",
+                  background: "#ff0000",
+                  color: "#fff",
+                  borderRadius: "var(--radius)",
+                  fontWeight: 600,
+                  fontSize: "0.85rem",
+                  textDecoration: "none",
+                }}
               >
                 <Icon name="youtube" size={18} />
                 Neural_Update
@@ -90,12 +101,21 @@ const Footer = () => (
             href="https://www.youtube.com/@Neural_Update"
             target="_blank"
             rel="noopener noreferrer"
-            title="YouTube — Neural_Update"
-            style={{ display: "flex", alignItems: "center", color: "var(--fg-muted)", transition: "color 0.2s" }}
-            onMouseEnter={e => e.currentTarget.style.color = "#ff0000"}
-            onMouseLeave={e => e.currentTarget.style.color = "var(--fg-muted)"}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "6px 14px",
+              background: "#ff0000",
+              color: "#fff",
+              borderRadius: "var(--radius)",
+              fontWeight: 600,
+              fontSize: "0.8rem",
+              textDecoration: "none",
+            }}
           >
-            <Icon name="youtube" size={20} />
+            <Icon name="youtube" size={16} />
+            YouTube
           </a>
           <a href="privacy-policy.html" style={{ color: "var(--fg-muted)" }}>Polityka prywatności</a>
         </div>


### PR DESCRIPTION
## Summary

- **Polityka prywatności** — naprawiono zepsuty link `href="#"` w checkboxie formularza kontaktowego (teraz prowadzi do `privacy-policy.html`)
- **Baner cookies** — dodano komponent `CookieBanner` (localStorage, przyciski Akceptuję/Odrzuć, link do polityki prywatności) na wszystkich podstronach
- **Formularz kontaktowy (Netlify)** — dodano `data-netlify`, `name/method/action`, ukryty `form-name`, atrybuty `name` na wszystkich polach, ochronę antyspamową (honeypot) oraz statyczny ukryty formularz w `index.html` wymagany przez Netlify build bot
- **Ikona YouTube** — dodano czerwony przycisk z ikoną kierujący do kanału `@Neural_Update` w kolumnie "Kontakt" oraz w pasku dolnym stopki

## Test plan

- [ ] Kliknięcie "Polityka Prywatności" w formularzu otwiera `privacy-policy.html`
- [ ] Baner cookies pojawia się przy pierwszej wizycie i znika po kliknięciu Akceptuję/Odrzuć
- [ ] Formularz kontaktowy wysyła dane do Netlify i przekierowuje na `success.html`
- [ ] Czerwone przyciski YouTube w stopce prowadzą do `https://www.youtube.com/@Neural_Update`

https://claude.ai/code/session_01ASg6iQHmLm2LuPfYeWhJQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASg6iQHmLm2LuPfYeWhJQT)_