### PR TITLE
fix(sitemap): replace with clean valid XML structure

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,33 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://brightmindsolutions.pl/</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/o-mnie.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/o-mnie.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/ai-w-praktyce.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/ai-w-praktyce.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/NIS2.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/NIS2.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/privacy-policy.html</loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,33 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://brightmindsolutions.pl/</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/o-mnie.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/o-mnie.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/ai-w-praktyce.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/ai-w-praktyce.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/NIS2.html</loc>
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="pl" href="https://brightmindsolutions.pl/NIS2.html"/>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/privacy-policy.html</loc>


### PR DESCRIPTION
Removes xhtml namespace and xhtml:link alternates that were causing Google Search Console to reject the sitemap. Keeps both root and public/ copies in sync.