### PR TITLE
Fix Plausible analytics: inject into Astro Layout + whitelist in CSP

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -81,6 +81,13 @@ const resolvedOgDesc = ogDescription ?? description;
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/styles.css" />
 
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script is:inline async src="https://plausible.io/js/pa-YOjnFuvYPJadUrR0uHLdh.js"></script>
+  <script is:inline>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init();
+  </script>
+
   {ldJson.map(schema => (
     <script type="application/ld+json" set:html={JSON.stringify(schema)} />
   ))}


### PR DESCRIPTION
## Summary

Plausible was reporting "We couldn't detect Plausible on your site". Two root causes:

1. **Snippet was added to the wrong file.** The site is built by Astro from `src/`, so the root `index.html` is unused in production. The tracker has been moved into `src/layouts/Layout.astro` (with `is:inline` so Astro doesn't transform it), which means every generated page now includes it: `/`, `/o-mnie/`, `/ai-w-praktyce/`, `/NIS2/`, `/privacy-policy/`, `/success/`.
2. **CSP was blocking `plausible.io`.** `_headers` whitelisted only Facebook/unpkg under `script-src` and `connect-src`. Added `https://plausible.io` to both directives so the tracker can load and report events.

## Test plan

- [ ] Merge to `main` and wait for Netlify deploy.
- [ ] `view-source:https://brightmindsolutions.pl/` contains `<script async src="https://plausible.io/js/pa-YOjnFuvYPJadUrR0uHLdh.js">`.
- [ ] DevTools → Network: `pa-YOjnFuvYPJadUrR0uHLdh.js` loads with 200 and no CSP violation in Console.
- [ ] Plausible dashboard → "Verify installation again" succeeds.
- [ ] Confirm same on `/o-mnie/`, `/ai-w-praktyce/`, `/NIS2/`, `/privacy-policy/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFZUiLgjBjBv6YSN9uavQQ)_