### PR TITLE
Document Plausible analytics in privacy policy

### DIFF
--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -5,7 +5,7 @@ import CookieBanner from '../components/CookieBanner.jsx';
 
 <Layout
   title="Polityka Prywatności | BrightMind AI Solutions"
-  description="Polityka prywatności i ochrony danych osobowych BrightMind AI Solutions. Informacje o przetwarzaniu danych zgodnie z RODO i wykorzystaniu Facebook Pixel."
+  description="Polityka prywatności i ochrony danych osobowych BrightMind AI Solutions. Informacje o przetwarzaniu danych zgodnie z RODO oraz wykorzystaniu Facebook Pixel i analityki Plausible."
   canonical="https://brightmindsolutions.pl/privacy-policy/"
   robots="index, follow"
 >
@@ -125,12 +125,29 @@ import CookieBanner from '../components/CookieBanner.jsx';
           <li>Tworzenia grup odbiorców do remarketingu</li>
           <li>Optymalizacji kampanii reklamowych</li>
         </ul>
-        <p class="text-muted">Możesz zrezygnować z śledzenia przez Facebook Pixel w ustawieniach Facebooka lub przez <a href="https://www.facebook.com/privacy/explanation" target="_blank" rel="noopener noreferrer">Centrum prywatności Facebook</a>. Pliki cookie możesz wyłączyć w ustawieniach przeglądarki.</p>
+        <p class="text-muted" style="margin-bottom:12px">Możesz zrezygnować z śledzenia przez Facebook Pixel w ustawieniach Facebooka lub przez <a href="https://www.facebook.com/privacy/explanation" target="_blank" rel="noopener noreferrer">Centrum prywatności Facebook</a>. Pliki cookie możesz wyłączyć w ustawieniach przeglądarki.</p>
+        <p class="text-muted">Niezależnie od Facebook Pixel, do anonimowej analizy ruchu wykorzystujemy Plausible Analytics, które <strong style="color:var(--fg)">nie używa plików cookie</strong> — szczegóły opisujemy w sekcji 08 poniżej.</p>
       </div>
 
       <div style="padding-bottom:32px;margin-bottom:32px;border-bottom:1px solid var(--border)">
         <div style="display:flex;gap:16px;align-items:baseline;margin-bottom:16px">
           <span class="mono accent" style="font-size:0.8rem">08</span>
+          <h2 style="margin:0;font-size:1.25rem">Analityka Strony — Plausible</h2>
+        </div>
+        <p class="text-muted" style="margin-bottom:12px">Do analizy ruchu na stronie wykorzystujemy <strong style="color:var(--fg)">Plausible Analytics</strong> — narzędzie analityczne przyjazne prywatności:</p>
+        <ul style="color:var(--fg-muted);padding-left:20px;line-height:2;margin-bottom:12px">
+          <li><strong style="color:var(--fg)">Nie wykorzystuje plików cookie</strong> ani innych identyfikatorów przechowywanych na Twoim urządzeniu</li>
+          <li><strong style="color:var(--fg)">Nie zbiera danych osobowych</strong> ani danych umożliwiających identyfikację użytkownika</li>
+          <li>Nie śledzi użytkowników pomiędzy stronami ani urządzeniami</li>
+          <li>Gromadzi wyłącznie zagregowane, anonimowe statystyki (np. liczba odwiedzin, źródła ruchu, typ urządzenia)</li>
+          <li>Dane są przetwarzane i przechowywane na serwerach w Unii Europejskiej</li>
+        </ul>
+        <p class="text-muted">Ponieważ Plausible nie używa plików cookie i nie przetwarza danych osobowych, korzystanie z niego nie wymaga Twojej zgody w rozumieniu RODO. Więcej informacji znajdziesz w <a href="https://plausible.io/privacy-focused-web-analytics" target="_blank" rel="noopener noreferrer">polityce prywatności Plausible</a>.</p>
+      </div>
+
+      <div style="padding-bottom:32px;margin-bottom:32px;border-bottom:1px solid var(--border)">
+        <div style="display:flex;gap:16px;align-items:baseline;margin-bottom:16px">
+          <span class="mono accent" style="font-size:0.8rem">09</span>
           <h2 style="margin:0;font-size:1.25rem">Bezpieczeństwo Danych</h2>
         </div>
         <p class="text-muted">Stosujemy odpowiednie środki techniczne i organizacyjne w celu ochrony danych osobowych przed nieautoryzowanym dostępem, utratą lub zniszczeniem.</p>
@@ -138,7 +155,7 @@ import CookieBanner from '../components/CookieBanner.jsx';
 
       <div style="padding-bottom:32px;margin-bottom:32px;border-bottom:1px solid var(--border)">
         <div style="display:flex;gap:16px;align-items:baseline;margin-bottom:16px">
-          <span class="mono accent" style="font-size:0.8rem">09</span>
+          <span class="mono accent" style="font-size:0.8rem">10</span>
           <h2 style="margin:0;font-size:1.25rem">Kontakt w Sprawach Danych</h2>
         </div>
         <p class="text-muted">W sprawach dotyczących ochrony danych osobowych można kontaktować się z administratorem:<br />
@@ -148,10 +165,10 @@ import CookieBanner from '../components/CookieBanner.jsx';
 
       <div>
         <div style="display:flex;gap:16px;align-items:baseline;margin-bottom:16px">
-          <span class="mono accent" style="font-size:0.8rem">10</span>
+          <span class="mono accent" style="font-size:0.8rem">11</span>
           <h2 style="margin:0;font-size:1.25rem">Zmiany Polityki Prywatności</h2>
         </div>
-        <p class="text-muted">Zastrzegamy prawo do zmiany niniejszej Polityki Prywatności. O istotnych zmianach poinformujemy na stronie internetowej. Data ostatniej aktualizacji: 2026-05-20.</p>
+        <p class="text-muted">Zastrzegamy prawo do zmiany niniejszej Polityki Prywatności. O istotnych zmianach poinformujemy na stronie internetowej. Data ostatniej aktualizacji: 2026-06-15.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Documents the newly added Plausible analytics in the privacy policy (`src/pages/privacy-policy.astro` — the Astro source built to production).

- **New section 08 — "Analityka Strony — Plausible"**: describes Plausible as cookieless, privacy-friendly analytics that collects no personal data, doesn't track across sites/devices, stores aggregated data in the EU, and requires no consent under GDPR/RODO. Links to Plausible's privacy page.
- **Cookies section (07)**: adds a reference to Plausible alongside Facebook Pixel, noting it does not use cookies.
- **Renumbered** subsequent sections to stay sequential (Bezpieczeństwo 09, Kontakt 10, Zmiany 11).
- **Bumped** last-updated date to 2026-06-15 and updated the page meta description.

Astro build passes; generated `dist/privacy-policy/index.html` contains the new section, sequential numbering 01–11, and the Plausible script in `<head>`.

## Test plan

- [ ] Merge to `main` and wait for Netlify deploy.
- [ ] Visit `/privacy-policy/` and confirm section 08 describes Plausible and numbering runs 01–11.
- [ ] Confirm last-updated date shows 2026-06-15.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFZUiLgjBjBv6YSN9uavQQ)_