### PR TITLE
Dodanie sekcji blog (5 artykułów) zgodnie z audytem SEO/GEO

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://brightmindsolutions.pl/</loc>
-    <lastmod>2026-05-12</lastmod>
+    <lastmod>2026-06-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -23,6 +23,42 @@
     <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/nis2-dla-msp-checklista-90-dni/</loc>
+    <lastmod>2026-06-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/ile-kosztuje-wdrozenie-ai-w-firmie-b2b/</loc>
+    <lastmod>2026-06-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/n8n-vs-zapier-automatyzacja-dla-firm/</loc>
+    <lastmod>2026-06-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/lokalne-llm-dla-firm/</loc>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/7-zastosowan-agentow-ai-w-firmie/</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/privacy-policy.html</loc>

--- a/public/styles.css
+++ b/public/styles.css
@@ -454,3 +454,247 @@ a:hover { color: var(--accent-strong); }
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
+
+/* ============================================================
+   BLOG
+   ============================================================ */
+
+/* Blog listing cards */
+.post-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.2s;
+  height: 100%;
+}
+.post-card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+}
+.post-card a { color: inherit; }
+.post-cover {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  display: grid;
+  place-items: center;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(ellipse 90% 80% at 30% 10%, var(--accent-soft), transparent 60%),
+    var(--bg-elev-2);
+  overflow: hidden;
+}
+.post-cover svg { color: var(--accent); opacity: 0.9; }
+.post-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--border-strong) 1px, transparent 1px);
+  background-size: 22px 22px;
+  opacity: 0.18;
+  pointer-events: none;
+}
+.post-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  flex: 1;
+}
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--fg-dim);
+  letter-spacing: 0.03em;
+}
+.post-card h3 {
+  font-size: 1.2rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+}
+.post-card:hover h3 { color: var(--accent); }
+.post-card .post-excerpt {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  flex: 1;
+}
+.post-readmore {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+/* Category tag */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  white-space: nowrap;
+}
+
+/* Article (single post) */
+.article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+.article-header { padding: 64px 0 40px; }
+.article-cover {
+  position: relative;
+  aspect-ratio: 21 / 9;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: grid;
+  place-items: center;
+  margin: 8px 0 40px;
+  background:
+    radial-gradient(ellipse 80% 70% at 25% 0%, var(--accent-soft), transparent 60%),
+    var(--bg-elev);
+  overflow: hidden;
+}
+.article-cover svg { color: var(--accent); width: 64px; height: 64px; }
+.article-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--border-strong) 1px, transparent 1px);
+  background-size: 24px 24px;
+  opacity: 0.16;
+}
+
+/* Prose typography for article bodies */
+.prose { font-size: 1.06rem; line-height: 1.8; color: var(--fg); }
+.prose > * + * { margin-top: 24px; }
+.prose h2 {
+  font-size: 1.7rem;
+  margin-top: 56px;
+  padding-top: 8px;
+  scroll-margin-top: 88px;
+}
+.prose h3 {
+  font-size: 1.25rem;
+  margin-top: 40px;
+  scroll-margin-top: 88px;
+}
+.prose p { color: var(--fg); }
+.prose a { text-decoration: underline; text-underline-offset: 3px; text-decoration-color: var(--border-strong); }
+.prose a:hover { text-decoration-color: var(--accent); }
+.prose strong { color: var(--fg); font-weight: 600; }
+.prose ul, .prose ol { padding-left: 24px; margin-top: 20px; }
+.prose li { margin-top: 10px; padding-left: 4px; }
+.prose li::marker { color: var(--accent); }
+.prose blockquote {
+  border-left: 2px solid var(--accent);
+  padding: 4px 0 4px 24px;
+  margin: 32px 0;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+.prose hr { border: none; border-top: 1px solid var(--border); margin: 48px 0; }
+
+/* Callout box inside articles */
+.callout {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 20px 24px;
+  margin: 32px 0;
+}
+.callout p { margin: 0; color: var(--fg-muted); }
+.callout strong { color: var(--fg); }
+
+/* Key-takeaways / TL;DR */
+.takeaways {
+  background: linear-gradient(180deg, var(--accent-soft), transparent 60%), var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  margin: 8px 0 40px;
+}
+.takeaways h2 { font-size: 0.8rem !important; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin: 0 0 14px !important; padding: 0 !important; }
+.takeaways ul { margin: 0; padding-left: 22px; }
+.takeaways li { margin-top: 8px; color: var(--fg-muted); }
+
+/* Article table */
+.prose .table-wrap { overflow-x: auto; margin: 32px 0; }
+.prose table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.prose th, .prose td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--border); }
+.prose th { font-weight: 600; color: var(--fg); border-bottom: 1px solid var(--border-strong); }
+.prose td { color: var(--fg-muted); }
+
+/* Author / bio box */
+.author-box {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  margin-top: 56px;
+}
+.author-box img {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--border-strong);
+  flex-shrink: 0;
+}
+.author-box .author-name { font-weight: 600; }
+.author-box .author-role { font-size: 0.85rem; color: var(--fg-muted); margin: 4px 0 10px; }
+
+/* Breadcrumbs */
+.breadcrumbs {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--fg-dim);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.breadcrumbs a { color: var(--fg-muted); }
+.breadcrumbs a:hover { color: var(--accent); }
+
+/* Inline CTA strip */
+.cta-strip {
+  text-align: center;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 40px 32px;
+  margin: 56px 0 8px;
+}
+
+@media (max-width: 600px) {
+  .article, .article-header { padding-left: 20px; padding-right: 20px; }
+  .author-box { flex-direction: column; gap: 16px; }
+}

--- a/src/components/BlogCover.astro
+++ b/src/components/BlogCover.astro
@@ -1,0 +1,22 @@
+---
+// Dekoracyjna grafika nagłówkowa wpisu — dobierana po `hue` z metadanych posta.
+// SVG (a nie <img>) trzyma stronę lekką, ale daje wizualny sygnał dla UX i rich resultów.
+export interface Props { hue?: string; size?: number; }
+const { hue = 'bot', size = 64 } = Astro.props;
+const s = size;
+---
+{hue === 'shield' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+)}
+{hue === 'cost' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v10M9.5 9.2c0-1.1 1.1-1.7 2.5-1.7s2.5.7 2.5 1.7-1.1 1.6-2.5 1.8-2.5.8-2.5 1.8 1.1 1.7 2.5 1.7 2.5-.6 2.5-1.7"/></svg>
+)}
+{hue === 'flow' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="6" height="6" rx="1.5"/><rect x="15" y="3" width="6" height="6" rx="1.5"/><rect x="9" y="15" width="6" height="6" rx="1.5"/><path d="M6 9v3a2 2 0 002 2h1M18 9v3a2 2 0 01-2 2h-1"/></svg>
+)}
+{hue === 'lock' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 018 0v3"/><circle cx="12" cy="15.5" r="1.2"/></svg>
+)}
+{hue === 'bot' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="8" width="18" height="12" rx="2"/><path d="M12 8V4M8 4h8"/><circle cx="9" cy="14" r="1"/><circle cx="15" cy="14" r="1"/></svg>
+)}

--- a/src/data/blog-posts.js
+++ b/src/data/blog-posts.js
@@ -1,0 +1,107 @@
+// Centralna lista artykułów blogowych — źródło prawdy dla /blog/ oraz pojedynczych wpisów.
+// Każdy wpis ma odpowiadającą stronę w src/pages/blog/<slug>.astro
+export const SITE = 'https://brightmindsolutions.pl';
+
+export const author = {
+  name: 'Patryk Gliński',
+  jobTitle: 'Radca prawny · Ekspert AI · Założyciel BrightMind AI Solutions',
+  url: `${SITE}/o-mnie/`,
+  image: `${SITE}/IMG_0406.jpg`,
+  sameAs: [
+    'https://www.youtube.com/@Neural_Update',
+    'https://www.linkedin.com/in/patryk-gli%C5%84ski-172370215',
+  ],
+};
+
+// Kolejność w tablicy = kolejność wyświetlania na liście bloga (najnowsze pierwsze).
+export const posts = [
+  {
+    slug: 'nis2-dla-msp-checklista-90-dni',
+    title: 'NIS2 dla MŚP — checklista wdrożenia w 90 dni',
+    description:
+      'Praktyczny przewodnik po wdrożeniu dyrektywy NIS2 w małej i średniej firmie. Checklista 90 dni, analiza luki, polityki bezpieczeństwa, raportowanie incydentów i odpowiedzialność zarządu.',
+    excerpt:
+      'Dyrektywa NIS2 obejmuje znacznie więcej firm niż jej poprzedniczka. Pokazuję krok po kroku, jak w 90 dni przejść od zera do zgodności — bez kosztownego konsultingu korporacyjnego.',
+    category: 'Compliance NIS2',
+    date: '2026-06-16',
+    dateModified: '2026-06-16',
+    readingTime: 16,
+    keywords:
+      'NIS2 dla MŚP, wdrożenie NIS2, checklista NIS2, audyt NIS2 cena, dyrektywa NIS2 małe firmy, compliance NIS2, cyberbezpieczeństwo MŚP',
+    cover: { hue: 'shield', label: 'Compliance' },
+  },
+  {
+    slug: 'ile-kosztuje-wdrozenie-ai-w-firmie-b2b',
+    title: 'Ile kosztuje wdrożenie AI w firmie? Realne widełki B2B na 2026',
+    description:
+      'Przejrzysty rozkład kosztów wdrożenia AI w firmie B2B: licencje modeli, automatyzacje, agenci AI, koszty ukryte i zwrot z inwestycji. Konkretne widełki w złotówkach.',
+    excerpt:
+      'Najczęstsze pytanie od klientów: „ile to kosztuje?”. Rozbijam koszty wdrożenia AI na czynniki pierwsze — od abonamentu za model po koszt utrzymania — i pokazuję, kiedy inwestycja się zwraca.',
+    category: 'Wdrożenia AI',
+    date: '2026-06-09',
+    dateModified: '2026-06-09',
+    readingTime: 12,
+    keywords:
+      'ile kosztuje wdrożenie AI, koszty AI B2B, cena automatyzacji AI, ROI sztucznej inteligencji, budżet AI dla firmy',
+    cover: { hue: 'cost', label: 'Koszty i ROI' },
+  },
+  {
+    slug: 'n8n-vs-zapier-automatyzacja-dla-firm',
+    title: 'n8n vs Zapier — którą platformę automatyzacji wybrać w 2026?',
+    description:
+      'Porównanie n8n i Zapier dla firm: koszty, hosting własny vs chmura, prywatność danych, integracje AI, limity i scenariusze, w których wygrywa każde z narzędzi.',
+    excerpt:
+      'n8n czy Zapier? To nie jest pytanie o „lepsze narzędzie”, tylko o model kosztów, kontrolę nad danymi i skalę. Porównuję oba pod kątem realnych wdrożeń B2B.',
+    category: 'Automatyzacja',
+    date: '2026-06-02',
+    dateModified: '2026-06-02',
+    readingTime: 11,
+    keywords:
+      'n8n vs Zapier, automatyzacja procesów, n8n self-hosted, Zapier alternatywa, automatyzacja AI dla firm, no-code automatyzacja',
+    cover: { hue: 'flow', label: 'Automatyzacja' },
+  },
+  {
+    slug: 'lokalne-llm-dla-firm',
+    title: 'Lokalne modele LLM dla firm — kiedy warto i jak zacząć',
+    description:
+      'Lokalne modele LLM (Llama, Mistral, Qwen) na własnej infrastrukturze: prywatność danych, zgodność z RODO i NIS2, wymagania sprzętowe, koszty i kiedy lokalny model bije API chmurowe.',
+    excerpt:
+      'Nie każda firma może wysyłać dane do chmury OpenAI czy Anthropic. Lokalne LLM to dziś realna alternatywa — pokazuję, kiedy się opłacają, jakiego sprzętu wymagają i od czego zacząć.',
+    category: 'Bezpieczeństwo',
+    date: '2026-05-26',
+    dateModified: '2026-05-26',
+    readingTime: 13,
+    keywords:
+      'lokalne LLM, lokalne modele LLM dla firm, Llama dla firmy, prywatność danych AI, RODO AI, on-premise LLM, Ollama firma',
+    cover: { hue: 'lock', label: 'Prywatność' },
+  },
+  {
+    slug: '7-zastosowan-agentow-ai-w-firmie',
+    title: '7 zastosowań agentów AI w firmie — od obsługi klienta po analizę dokumentów',
+    description:
+      'Siedem konkretnych use case’ów agentów AI dla firm B2B: obsługa klienta, kwalifikacja leadów, analiza dokumentów, raportowanie, monitoring, onboarding i research. Z opisem wdrożenia.',
+    excerpt:
+      'Agent AI to nie chatbot. To system, który samodzielnie wykonuje wieloetapowe zadania. Pokazuję 7 zastosowań, które realnie oszczędzają godziny pracy w polskich firmach.',
+    category: 'Agenci AI',
+    date: '2026-05-19',
+    dateModified: '2026-05-19',
+    readingTime: 12,
+    keywords:
+      'agenci AI dla firm, zastosowania agentów AI, AI agent use case, automatyzacja obsługi klienta AI, agent AI analiza dokumentów',
+    cover: { hue: 'bot', label: 'Agenci AI' },
+  },
+];
+
+export const getPost = (slug) => posts.find((p) => p.slug === slug);
+
+// Zwraca do `limit` innych wpisów (do sekcji „Powiązane artykuły”).
+export const relatedPosts = (slug, limit = 2) =>
+  posts.filter((p) => p.slug !== slug).slice(0, limit);
+
+// Formatowanie daty po polsku, np. „16 czerwca 2026”.
+export const formatDate = (iso) =>
+  new Date(iso).toLocaleDateString('pl-PL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,0 +1,204 @@
+---
+import Layout from './Layout.astro';
+import BlogCover from '../components/BlogCover.astro';
+import CookieBanner from '../components/CookieBanner.jsx';
+import { SITE, author, getPost, relatedPosts, formatDate } from '../data/blog-posts.js';
+
+export interface Props { slug: string; }
+const { slug } = Astro.props;
+
+const post = getPost(slug);
+if (!post) throw new Error(`Brak metadanych wpisu dla slug: ${slug}`);
+const url = `${SITE}/blog/${post.slug}/`;
+const related = relatedPosts(post.slug, 2);
+
+const ldJson = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": post.title,
+    "description": post.description,
+    "url": url,
+    "mainEntityOfPage": { "@type": "WebPage", "@id": url },
+    "datePublished": post.date,
+    "dateModified": post.dateModified ?? post.date,
+    "inLanguage": "pl-PL",
+    "articleSection": post.category,
+    "keywords": post.keywords,
+    "image": `${SITE}/og-image.jpg`,
+    "author": {
+      "@type": "Person",
+      "name": author.name,
+      "url": author.url,
+      "sameAs": author.sameAs
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "BrightMind AI Solutions",
+      "url": `${SITE}/`,
+      "logo": { "@type": "ImageObject", "url": `${SITE}/og-image.jpg` }
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Strona Główna", "item": `${SITE}/` },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": `${SITE}/blog/` },
+      { "@type": "ListItem", "position": 3, "name": post.title, "item": url }
+    ]
+  }
+];
+---
+
+<Layout
+  title={`${post.title} | Blog BrightMind AI Solutions`}
+  description={post.description}
+  canonical={url}
+  ogType="article"
+  keywords={post.keywords}
+  ldJson={ldJson}
+  fbPixelId="857800850017857"
+>
+  <nav class="nav">
+    <div class="container nav-inner">
+      <a href="/" class="nav-brand">
+        <span class="nav-brand-mark">B</span>
+        <span>BrightMind <span style="color:var(--fg-muted)">/ AI</span></span>
+      </a>
+      <div class="nav-links">
+        <a href="/">Strona Główna</a>
+        <a href="/o-mnie/">O mnie</a>
+        <a href="/#uslugi">Usługi</a>
+        <a href="/NIS2/">NIS2</a>
+        <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/" class="active">Blog</a>
+        <a href="/#kontakt">Kontakt</a>
+        <a href="/#kontakt" class="nav-cta">Bezpłatna konsultacja →</a>
+      </div>
+    </div>
+  </nav>
+
+  <article>
+    <header class="article-header">
+      <div class="article">
+        <nav class="breadcrumbs" aria-label="Ścieżka nawigacji">
+          <a href="/">Start</a><span>/</span>
+          <a href="/blog/">Blog</a><span>/</span>
+          <span class="text-muted">{post.category}</span>
+        </nav>
+        <div style="margin-top:20px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+          <span class="tag">{post.category}</span>
+          <span class="post-meta"><time datetime={post.date}>{formatDate(post.date)}</time> · {post.readingTime} min czytania</span>
+        </div>
+        <h1 style="margin-top:18px;font-size:clamp(2rem,4vw,3rem)">{post.title}</h1>
+        <p class="text-muted" style="font-size:1.15rem;margin-top:18px;max-width:680px">{post.excerpt}</p>
+        <div class="article-cover" role="img" aria-label={`Ilustracja artykułu: ${post.title}`}>
+          <BlogCover hue={post.cover?.hue} />
+        </div>
+      </div>
+    </header>
+
+    <div class="article prose">
+      <slot />
+
+      <div class="author-box">
+        <img src={author.image} alt="Patryk Gliński — radca prawny i ekspert AI, autor wpisu" loading="lazy" width="72" height="72" />
+        <div>
+          <div class="author-name">{author.name}</div>
+          <div class="author-role">{author.jobTitle}</div>
+          <p class="text-muted" style="margin:0;font-size:0.92rem">Łączę praktykę prawniczą z certyfikatami Google Cloud Generative AI Leader i Blue Team (HackerU). Pomagam polskim firmom bezpiecznie wdrażać AI i spełniać wymogi NIS2. <a href="/o-mnie/">Poznaj mnie →</a></p>
+        </div>
+      </div>
+
+      <div class="cta-strip">
+        <span class="eyebrow">/ Współpraca</span>
+        <h2 style="margin:14px 0 12px;border:none;padding:0">Potrzebujesz wsparcia we wdrożeniu AI?</h2>
+        <p class="text-muted" style="max-width:520px;margin:0 auto 24px">Umów bezpłatną konsultację — przeanalizujemy procesy w Twojej firmie i wskażemy, gdzie AI realnie oszczędzi czas i pieniądze.</p>
+        <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap">
+          <a href="/#kontakt" class="btn btn-primary">Bezpłatna konsultacja
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+          </a>
+          <a href="mailto:kontakt@brightmind-solutions.com" class="btn btn-secondary">Napisz e-mail</a>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  {related.length > 0 && (
+    <section class="section" style="background:var(--bg-elev)">
+      <div class="container">
+        <div class="section-header" style="margin-bottom:32px">
+          <span class="eyebrow">/ Czytaj dalej</span>
+          <h2>Powiązane artykuły</h2>
+        </div>
+        <div class="grid grid-2">
+          {related.map(r => (
+            <a href={`/blog/${r.slug}/`} class="post-card">
+              <div class="post-cover"><BlogCover hue={r.cover?.hue} size={44} /></div>
+              <div class="post-body">
+                <div class="post-meta"><span class="tag">{r.category}</span> · {r.readingTime} min</div>
+                <h3>{r.title}</h3>
+                <p class="post-excerpt">{r.excerpt}</p>
+                <span class="post-readmore">Czytaj artykuł
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+                </span>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <div class="nav-brand" style="margin-bottom:16px">
+            <span class="nav-brand-mark">B</span>
+            <span>BrightMind <span style="color:var(--fg-muted)">/ AI</span></span>
+          </div>
+          <p class="text-muted" style="font-size:0.9rem;max-width:320px">Profesjonalne wdrożenia AI B2B dla polskich firm. Automatyzacja procesów, agenci AI, doradztwo. Zgodne z RODO i NIS2.</p>
+        </div>
+        <div class="footer-col">
+          <h4>Usługi</h4>
+          <ul>
+            <li><a href="/#uslugi">Doradztwo AI dla Firm</a></li>
+            <li><a href="/#uslugi">Korepetycje AI</a></li>
+            <li><a href="/NIS2/">Wdrożenia NIS2</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Firma</h4>
+          <ul>
+            <li><a href="/o-mnie/">O mnie</a></li>
+            <li><a href="/ai-w-praktyce/">AI w Praktyce</a></li>
+            <li><a href="/blog/">Blog</a></li>
+            <li><a href="/#kontakt">Kontakt</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Kontakt</h4>
+          <ul style="font-size:0.85rem;color:var(--fg-muted)">
+            <li>Patryk Gliński</li>
+            <li><a href="mailto:kontakt@brightmind-solutions.com">kontakt@brightmind-solutions.com</a></li>
+            <li><a href="tel:+48730152161">+48 730 152 161</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2026 BrightMind AI Solutions. Wszystkie prawa zastrzeżone.</span>
+        <div style="display:flex;align-items:center;gap:20px">
+          <a href="https://www.youtube.com/@Neural_Update" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:8px;padding:6px 14px;background:#ff0000;color:#fff;border-radius:var(--radius);font-weight:600;font-size:0.8rem;text-decoration:none">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="14" rx="3"/><polygon points="10 9.5 16 13 10 16.5 10 9.5"/></svg>
+            YouTube
+          </a>
+          <a href="/privacy-policy/" style="color:var(--fg-muted)">Polityka prywatności</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <CookieBanner client:load />
+</Layout>

--- a/src/pages/NIS2.astro
+++ b/src/pages/NIS2.astro
@@ -79,6 +79,7 @@ const ldJson = [
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/" class="active">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="#kontakt">Kontakt</a>
         <a href="#kontakt" class="nav-cta">Bezpłatna konsultacja →</a>

--- a/src/pages/ai-w-praktyce.astro
+++ b/src/pages/ai-w-praktyce.astro
@@ -50,6 +50,7 @@ const ldJson = [
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/" class="active">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="/#kontakt">Kontakt</a>
         <a href="/en/ai-in-practice.html" class="lang-switch" aria-label="English version" style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border:1px solid var(--border);border-radius:var(--radius);font-size:0.8rem;color:var(--fg-muted);text-decoration:none">

--- a/src/pages/blog/7-zastosowan-agentow-ai-w-firmie.astro
+++ b/src/pages/blog/7-zastosowan-agentow-ai-w-firmie.astro
@@ -1,0 +1,87 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="7-zastosowan-agentow-ai-w-firmie">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <ul>
+      <li><strong>Agent AI to nie chatbot</strong> — to system, który samodzielnie wykonuje wieloetapowe zadania z dostępem do narzędzi i danych firmy.</li>
+      <li>Najlepsze pierwsze wdrożenia celują w zadania <strong>powtarzalne, czasochłonne i oparte na regułach</strong>.</li>
+      <li>Poniżej 7 konkretnych use case’ów, które realnie oszczędzają godziny pracy w polskich firmach B2B.</li>
+      <li>Przy danych wrażliwych łącz agenta z <strong>lokalnym LLM i n8n self-hosted</strong>, by zachować zgodność z RODO/NIS2.</li>
+    </ul>
+  </div>
+
+  <p>Wokół „agentów AI” narosło sporo szumu, więc zacznijmy od uziemienia pojęcia. <strong>Chatbot</strong> odpowiada na pytania. <strong>Agent AI</strong> wykonuje zadania: planuje kroki, korzysta z narzędzi (wyszukiwarka, baza danych, system firmy), podejmuje decyzje na podstawie wyniku i dąży do celu — często bez udziału człowieka na każdym etapie. To różnica między „doradcą, który mówi, co zrobić” a „pracownikiem, który to robi”. W tym artykule pokazuję 7 zastosowań, które nie są futurologią, lecz wdrażam je w realnych firmach.</p>
+
+  <h2>1. Inteligentna obsługa klienta pierwszej linii</h2>
+
+  <p>Agent odbiera zapytania z e-maila, formularza czy czatu, rozumie kontekst, sięga do bazy wiedzy i dokumentacji, a następnie udziela konkretnej odpowiedzi albo wykonuje akcję (np. sprawdza status zamówienia). W odróżnieniu od sztywnego chatbota radzi sobie z pytaniami sformułowanymi naturalnie i przekazuje sprawę człowiekowi dopiero wtedy, gdy faktycznie tego wymaga.</p>
+  <p><strong>Efekt:</strong> obsługa znacznej części zapytań poza godzinami pracy i odciążenie zespołu od powtarzalnych pytań. <em>Dla kogo:</em> e-commerce, usługi, firmy z dużym wolumenem zapytań.</p>
+
+  <h2>2. Kwalifikacja i obsługa leadów</h2>
+
+  <p>Po wypełnieniu formularza agent analizuje zgłoszenie, wzbogaca je o publicznie dostępne informacje, ocenia dopasowanie według Twoich kryteriów, nadaje priorytet i zakłada rekord w CRM — a do wartościowych leadów od razu wysyła spersonalizowaną odpowiedź. Handlowcy zamiast przesiewać kontakty, rozmawiają z gotowymi, ocenionymi szansami.</p>
+  <p><strong>Efekt:</strong> szybszy czas reakcji (kluczowy dla konwersji) i koniec z „przeoczonymi” zgłoszeniami. <em>Dla kogo:</em> B2B, usługi profesjonalne, software house.</p>
+
+  <h2>3. Analiza i ekstrakcja danych z dokumentów</h2>
+
+  <p>To jeden z najbardziej wartościowych obszarów. Agent czyta faktury, umowy, protokoły czy raporty, wyciąga kluczowe informacje (strony, kwoty, terminy, klauzule), porównuje je z regułami i sygnalizuje odstępstwa. Zamiast ręcznie przepisywać dane z PDF-ów do systemu, pracownik weryfikuje gotowy, ustrukturyzowany wynik.</p>
+  <div class="callout">
+    <p><strong>Uwaga na dane wrażliwe:</strong> przy umowach i dokumentach prawnych rekomenduję lokalny model LLM, żeby treści nie opuszczały firmy. To temat, który łączy się z compliance — jako radca prawny zwracam tu szczególną uwagę na zgodność z RODO.</p>
+  </div>
+  <p><strong>Efekt:</strong> eliminacja żmudnego przepisywania i mniej błędów. <em>Dla kogo:</em> księgowość, kancelarie, firmy z dużą liczbą umów i faktur.</p>
+
+  <h2>4. Automatyczne raportowanie i podsumowania</h2>
+
+  <p>Agent cyklicznie zbiera dane z różnych źródeł (arkusze, CRM, narzędzia analityczne), łączy je, wykrywa trendy i anomalie, a następnie generuje czytelny raport w naturalnym języku — gotowy do wysłania zarządowi. Zamiast spędzać poniedziałkowy poranek na sklejaniu liczb, otrzymujesz gotowe podsumowanie z wnioskami.</p>
+  <p><strong>Efekt:</strong> stałe, terminowe raporty bez ręcznej pracy. <em>Dla kogo:</em> zarządy, działy sprzedaży i marketingu, kierownicy operacyjni.</p>
+
+  <h2>5. Monitoring i wczesne ostrzeganie</h2>
+
+  <p>Agent obserwuje wybrane sygnały — wzmianki o marce, recenzje, zmiany u konkurencji, alerty z systemów, logi bezpieczeństwa — i reaguje, gdy dzieje się coś istotnego: powiadamia właściwą osobę, kategoryzuje zdarzenie i proponuje działanie. W kontekście cyberbezpieczeństwa taki agent może wstępnie klasyfikować alerty i odsiewać szum, zanim trafi on do człowieka.</p>
+  <p><strong>Efekt:</strong> szybsza reakcja i mniej przeoczonych sygnałów. <em>Dla kogo:</em> marketing, zespoły bezpieczeństwa, firmy pod NIS2.</p>
+
+  <h2>6. Onboarding i wewnętrzny asystent wiedzy</h2>
+
+  <p>Agent podpięty do wewnętrznej dokumentacji, procedur i bazy wiedzy odpowiada pracownikom na pytania „jak to zrobić u nas” — od polityki urlopowej po procedurę obsługi reklamacji. Nowy pracownik dostaje natychmiastowe, spójne odpowiedzi zamiast czekać na wolną chwilę kolegi, a wiedza firmowa przestaje zależeć od jednej osoby.</p>
+  <p><strong>Efekt:</strong> szybszy onboarding i odciążenie doświadczonych pracowników. <em>Dla kogo:</em> firmy rosnące, rozproszone zespoły, organizacje z rozbudowanymi procedurami.</p>
+
+  <h2>7. Research i przygotowanie materiałów</h2>
+
+  <p>Agent samodzielnie przeszukuje źródła, zbiera i porządkuje informacje na zadany temat, a następnie przygotowuje brief, draft oferty czy zestawienie. Człowiek dostaje solidny punkt startowy zamiast pustej kartki — i skupia się na ocenie oraz decyzji, a nie na zbieraniu danych.</p>
+  <p><strong>Efekt:</strong> krótszy czas od pomysłu do gotowego materiału. <em>Dla kogo:</em> marketing, sprzedaż, zespoły ofertowe, konsulting.</p>
+
+  <h2>Jak wybrać pierwszy use case</h2>
+
+  <p>Nie wdrażaj wszystkich siedmiu naraz. Najlepszy pierwszy projekt spełnia trzy warunki:</p>
+  <ul>
+    <li><strong>Powtarzalność</strong> — zadanie wykonywane regularnie i często.</li>
+    <li><strong>Czasochłonność</strong> — realnie pożera godziny pracy zespołu.</li>
+    <li><strong>Mierzalność</strong> — efekt da się policzyć (zaoszczędzone godziny, czas reakcji).</li>
+  </ul>
+
+  <blockquote>Zacznij od procesu, który jest nudny, powtarzalny i drogi w godzinach pracy. Tam agent AI daje najszybszy i najłatwiejszy do udowodnienia zwrot — a sukces pierwszego wdrożenia otwiera drzwi do kolejnych.</blockquote>
+
+  <h2>Architektura zgodna z prawem</h2>
+
+  <p>Agenci AI pracują na danych firmy, więc projektowanie pod kątem zgodności jest częścią wdrożenia, a nie dodatkiem. Dla danych wrażliwych łączę agenta z lokalnym modelem LLM i platformą n8n self-hosted, dzięki czemu informacje nie opuszczają infrastruktury klienta. To podejście, w którym <strong>automatyzacja idzie w parze z RODO i NIS2</strong> — szczególnie ważne w branżach regulowanych.</p>
+
+  <h2>Najczęstsze pytania</h2>
+
+  <h3>Czy agent AI zastąpi pracowników?</h3>
+  <p>W praktyce przejmuje powtarzalne, żmudne fragmenty pracy, a ludzie zajmują się tym, co wymaga osądu, relacji i kreatywności. Cel to wzmocnienie zespołu, nie jego eliminacja.</p>
+
+  <h3>Czy to bezpieczne dla danych firmy?</h3>
+  <p>Tak, jeśli architektura jest zaprojektowana pod kątem bezpieczeństwa: kontrola dostępu, minimalne uprawnienia, a dla danych wrażliwych — przetwarzanie lokalne. To kwestia projektu, nie przeszkoda nie do pokonania.</p>
+
+  <h3>Od czego zacząć?</h3>
+  <p>Od diagnozy: wskazania jednego procesu o wysokim ROI i niskim ryzyku. Pilotaż na takim procesie pozwala udowodnić wartość, zanim zainwestujesz w szersze wdrożenie.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> Agenci AI to dziś praktyczne narzędzie, które przejmuje konkretne, czasochłonne zadania — od obsługi klienta po analizę dokumentów. Klucz to dobrać pierwszy use case z głową i zadbać o zgodność od początku. Chcesz wiedzieć, który z tych siedmiu scenariuszy da największy zwrot w Twojej firmie? <a href="/#kontakt">Umów bezpłatną konsultację</a> — wskażemy proces, od którego warto zacząć.</p>
+
+</BlogLayout>

--- a/src/pages/blog/ile-kosztuje-wdrozenie-ai-w-firmie-b2b.astro
+++ b/src/pages/blog/ile-kosztuje-wdrozenie-ai-w-firmie-b2b.astro
@@ -1,0 +1,110 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="ile-kosztuje-wdrozenie-ai-w-firmie-b2b">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <ul>
+      <li>Koszt wdrożenia AI to nie jedna liczba — składają się na niego <strong>licencje modeli, praca wdrożeniowa, integracje i utrzymanie</strong>.</li>
+      <li>Pierwszy sensowny krok — <strong>diagnoza i pilotaż</strong> — mieści się zwykle w kilkuset–kilku tysiącach złotych.</li>
+      <li>Największe koszty ukryte to <strong>utrzymanie, zmiana procesów i jakość danych</strong>, a nie sam abonament za model.</li>
+      <li>Dobrze dobrany pierwszy projekt zwraca się, gdy <strong>oszczędność czasu × stawka godzinowa</strong> przewyższa koszt miesięczny utrzymania.</li>
+    </ul>
+  </div>
+
+  <p>„Ile kosztuje wdrożenie AI w firmie?” to pytanie, które słyszę najczęściej — i które ma najgorszą reputację, bo zwykle pada w odpowiedzi frustrujące „to zależy”. To prawda, ale za tym „zależy” kryje się przewidywalna struktura kosztów. W tym artykule rozbijam ją na czynniki pierwsze i podaję realne widełki dla polskiego rynku B2B w 2026 roku, żebyś mógł zaplanować budżet, zanim wykonasz pierwszy telefon do dostawcy.</p>
+
+  <h2>Cztery warstwy kosztów wdrożenia AI</h2>
+
+  <p>Każdy projekt AI — niezależnie od tego, czy to chatbot obsługi klienta, automatyzacja faktur czy agent analizujący dokumenty — można rozłożyć na cztery warstwy:</p>
+
+  <ol>
+    <li><strong>Model / licencja</strong> — koszt dostępu do „mózgu” (API modelu lub lokalny model na własnym sprzęcie).</li>
+    <li><strong>Praca wdrożeniowa</strong> — projekt, konfiguracja, integracje, testy.</li>
+    <li><strong>Infrastruktura i narzędzia</strong> — platformy automatyzacji, hosting, bazy wektorowe, monitoring.</li>
+    <li><strong>Utrzymanie</strong> — bieżące poprawki, aktualizacje, nadzór nad jakością i koszt zużycia (tokeny/serwer).</li>
+  </ol>
+
+  <p>Większość rozczarowań bierze się z patrzenia tylko na warstwę pierwszą („API kosztuje grosze za zapytanie!”) i ignorowania trzech pozostałych. Przejdźmy je po kolei.</p>
+
+  <h2>Warstwa 1: koszt modelu</h2>
+
+  <p>Modele językowe rozliczane są zwykle za <strong>tokeny</strong> (fragmenty tekstu na wejściu i wyjściu). Dla większości zastosowań biznesowych miesięczny koszt API liczonego per użycie to kwoty rzędu od kilkudziesięciu do kilkuset złotych przy umiarkowanym wolumenie — pod warunkiem dobrania właściwego modelu do zadania.</p>
+
+  <p>Kluczowa zasada: <strong>nie używaj najdroższego, największego modelu do wszystkiego.</strong> Do klasyfikacji e-maili czy ekstrakcji danych z faktur wystarczy mniejszy, tańszy i szybszy model; flagowy model rezerwujesz do zadań wymagających rozumowania. Dobór modelu do zadania potrafi obniżyć rachunek nawet dziesięciokrotnie. Aktualne cenniki i specyfikacje znajdziesz w dokumentacji dostawców, m.in. <a href="https://docs.claude.com/en/docs/about-claude/models" target="_blank" rel="noopener noreferrer">Anthropic (Claude)</a> czy <a href="https://platform.openai.com/docs/pricing" target="_blank" rel="noopener noreferrer">OpenAI</a>.</p>
+
+  <div class="callout">
+    <p><strong>Alternatywa:</strong> dla wrażliwych danych lub bardzo dużych wolumenów lokalny model LLM (np. z rodziny Llama czy Mistral) zmienia model kosztowy z „płać za każde zapytanie” na „zainwestuj raz w sprzęt”. Kiedy to się opłaca, rozkładam w osobnym artykule o lokalnych LLM.</p>
+  </div>
+
+  <h2>Warstwa 2: praca wdrożeniowa</h2>
+
+  <p>To zwykle największa pozycja w pierwszym projekcie i zależy od złożoności:</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Typ projektu</th><th>Zakres</th><th>Orientacyjny rząd wielkości</th></tr></thead>
+      <tbody>
+        <tr><td>Diagnoza / pilotaż</td><td>Analiza procesów, wybór use case, prosty prototyp</td><td>kilkaset–kilka tys. zł</td></tr>
+        <tr><td>Pojedyncza automatyzacja</td><td>Jeden zautomatyzowany proces z integracją</td><td>kilka–kilkanaście tys. zł</td></tr>
+        <tr><td>Agent / wieloetapowy workflow</td><td>Agent AI z dostępem do narzędzi i danych firmy</td><td>kilkanaście–kilkadziesiąt tys. zł</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>Widełki są szerokie celowo — różnica między „podłączmy formularz do modelu” a „zbudujmy agenta przeszukującego bazę umów” jest ogromna. Dlatego dobry wykonawca zaczyna od taniej diagnozy, a nie od wyceny całości w ciemno.</p>
+
+  <h2>Warstwa 3: infrastruktura i narzędzia</h2>
+
+  <p>Do działania automatyzacji potrzebujesz zwykle platformy łączącej systemy (np. <strong>n8n</strong> lub <strong>Zapier</strong>), czasem bazy wektorowej do wyszukiwania po dokumentach i monitoringu. Koszty zależą od wyboru:</p>
+
+  <ul>
+    <li><strong>n8n self-hosted</strong> — niski stały koszt serwera, pełna kontrola nad danymi.</li>
+    <li><strong>Zapier / platformy SaaS</strong> — abonament miesięczny rosnący z liczbą operacji.</li>
+    <li><strong>Hosting i bazy</strong> — od kilkudziesięciu złotych miesięcznie wzwyż.</li>
+  </ul>
+
+  <p>Porównanie n8n vs Zapier pod kątem kosztów i prywatności opisuję szczegółowo w osobnym wpisie — to często decyzja, która determinuje rachunek na kolejne lata.</p>
+
+  <h2>Warstwa 4: utrzymanie — najczęściej pomijana</h2>
+
+  <p>Wdrożenie nie kończy się w dniu uruchomienia. Modele i API się zmieniają, procesy biznesowe ewoluują, a automatyzacja wymaga nadzoru nad jakością. Realistyczny budżet zakłada <strong>miesięczny koszt utrzymania</strong> — czy to w formie wewnętrznego czasu, czy umowy wsparcia. To właśnie pominięcie tej warstwy sprawia, że wiele „udanych” pilotaży umiera pół roku po wdrożeniu.</p>
+
+  <h2>Koszty ukryte, o których nikt nie mówi</h2>
+
+  <ul>
+    <li><strong>Jakość danych.</strong> AI jest tak dobre, jak dane, które dostaje. Jeśli Twoje dokumenty są chaotyczne, część budżetu pójdzie na ich uporządkowanie. To inwestycja, która zwraca się też poza AI.</li>
+    <li><strong>Zarządzanie zmianą.</strong> Najlepsza automatyzacja jest bezwartościowa, jeśli zespół z niej nie korzysta. Szkolenia i adaptacja procesów to realny koszt.</li>
+    <li><strong>Bezpieczeństwo i zgodność.</strong> Przy danych osobowych dochodzi zgodność z RODO, a w niektórych branżach z NIS2 — warto uwzględnić to od początku, a nie naprawiać po fakcie.</li>
+  </ul>
+
+  <h2>Kiedy inwestycja się zwraca</h2>
+
+  <p>Prosty sposób na oszacowanie zwrotu z pierwszego projektu:</p>
+
+  <blockquote>(liczba godzin oszczędzonych miesięcznie × stawka godzinowa pracownika) − miesięczny koszt utrzymania = miesięczny zysk z automatyzacji</blockquote>
+
+  <p>Przykład: jeśli automatyzacja obsługi zapytań oszczędza 40 godzin pracy miesięcznie, a godzina pracownika kosztuje firmę realnie 60 zł, to oszczędność wynosi 2400 zł miesięcznie. Jeśli utrzymanie kosztuje 400 zł, projekt generuje 2000 zł miesięcznie i zwraca jednorazowy koszt wdrożenia w kilka miesięcy. To dlatego najlepsze pierwsze projekty celują w <strong>powtarzalne, czasochłonne i nudne</strong> zadania — tam ROI jest najwyższy i najszybszy.</p>
+
+  <div class="callout">
+    <p><strong>Rekomendacja:</strong> nie zaczynaj od wielkiego, ambitnego systemu. Zacznij od jednego procesu o wysokim wolumenie i niskim ryzyku, zmierz efekt, a dopiero potem skaluj. Pakiet diagnostyczny (u nas Start-AI) istnieje właśnie po to, by wskazać taki proces zanim wydasz większe pieniądze.</p>
+  </div>
+
+  <h2>Najczęstsze pytania o koszty AI</h2>
+
+  <h3>Czy małą firmę stać na AI?</h3>
+  <p>Tak — wiele wartościowych automatyzacji opiera się na narzędziach w modelu abonamentowym i istniejących licencjach. Bariera rzadko jest finansowa; częściej jest nią brak jasno wybranego pierwszego procesu.</p>
+
+  <h3>Lepiej API w chmurze czy model lokalny?</h3>
+  <p>Przy małym i średnim wolumenie oraz danych niewrażliwych API w chmurze jest tańsze i szybsze do uruchomienia. Przy dużych wolumenach lub danych wrażliwych model lokalny zaczyna wygrywać kosztowo i pod względem zgodności.</p>
+
+  <h3>Jak uniknąć przepłacenia?</h3>
+  <p>Zacznij od taniej diagnozy, dobieraj model do zadania, automatyzuj najpierw procesy o wysokim ROI i od początku planuj koszt utrzymania. Unikniesz w ten sposób trzech klasycznych pułapek: przeskalowania, przepłaconego modelu i „martwego” pilotażu.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> Koszt wdrożenia AI to suma czterech warstw, a nie cena samego modelu. Dla MŚP rozsądna ścieżka prowadzi przez tanią diagnozę, jeden dobrze dobrany proces i świadome planowanie utrzymania. Chcesz oszacować budżet dla konkretnego procesu w Twojej firmie? <a href="/#kontakt">Umów bezpłatną konsultację</a> — policzymy ROI, zanim wydasz pierwszą złotówkę.</p>
+
+</BlogLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,165 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import BlogCover from '../../components/BlogCover.astro';
+import CookieBanner from '../../components/CookieBanner.jsx';
+import { SITE, posts, formatDate } from '../../data/blog-posts.js';
+
+const ldJson = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "name": "Blog BrightMind AI Solutions",
+    "description": "Praktyczna wiedza o wdrożeniach AI B2B, automatyzacji procesów, agentach AI, lokalnych modelach LLM i compliance NIS2 dla polskich firm.",
+    "url": `${SITE}/blog/`,
+    "inLanguage": "pl-PL",
+    "publisher": { "@type": "Organization", "name": "BrightMind AI Solutions", "url": `${SITE}/` },
+    "blogPost": posts.map(p => ({
+      "@type": "BlogPosting",
+      "headline": p.title,
+      "description": p.description,
+      "url": `${SITE}/blog/${p.slug}/`,
+      "datePublished": p.date,
+      "dateModified": p.dateModified ?? p.date,
+      "articleSection": p.category,
+      "author": { "@type": "Person", "name": "Patryk Gliński", "url": `${SITE}/o-mnie/` }
+    }))
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Strona Główna", "item": `${SITE}/` },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": `${SITE}/blog/` }
+    ]
+  }
+];
+
+const [featured, ...rest] = posts;
+---
+
+<Layout
+  title="Blog AI dla firm — wdrożenia, automatyzacja, NIS2 | BrightMind AI Solutions"
+  description="Praktyczny blog o wdrożeniach AI B2B: koszty AI w firmie, n8n vs Zapier, lokalne modele LLM, agenci AI i checklista NIS2 dla MŚP. Wiedza z polskiego rynku."
+  canonical={`${SITE}/blog/`}
+  keywords="blog AI dla firm, wdrożenia AI B2B, automatyzacja procesów, agenci AI, lokalne LLM, NIS2 MŚP, koszty AI"
+  ldJson={ldJson}
+  fbPixelId="857800850017857"
+>
+  <nav class="nav">
+    <div class="container nav-inner">
+      <a href="/" class="nav-brand">
+        <span class="nav-brand-mark">B</span>
+        <span>BrightMind <span style="color:var(--fg-muted)">/ AI</span></span>
+      </a>
+      <div class="nav-links">
+        <a href="/">Strona Główna</a>
+        <a href="/o-mnie/">O mnie</a>
+        <a href="/#uslugi">Usługi</a>
+        <a href="/NIS2/">NIS2</a>
+        <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/" class="active">Blog</a>
+        <a href="/#kontakt">Kontakt</a>
+        <a href="/#kontakt" class="nav-cta">Bezpłatna konsultacja →</a>
+      </div>
+    </div>
+  </nav>
+
+  <section style="padding:80px 0 48px;border-bottom:1px solid var(--border)">
+    <div class="container">
+      <span class="eyebrow">/ Blog</span>
+      <h1 style="margin-top:16px;margin-bottom:12px">Wiedza o AI dla firm</h1>
+      <p class="text-muted" style="font-size:1.1rem;max-width:640px">
+        Praktyczne artykuły o wdrożeniach AI B2B, automatyzacji procesów, agentach AI, lokalnych modelach LLM i zgodności z NIS2. Bez marketingowego żargonu — konkrety, koszty i checklisty, które możesz wdrożyć u siebie.
+      </p>
+    </div>
+  </section>
+
+  <section class="section" style="padding-top:56px">
+    <div class="container">
+      <!-- Wyróżniony, najnowszy wpis -->
+      <a href={`/blog/${featured.slug}/`} class="post-card" style="margin-bottom:48px">
+        <div style="display:grid;grid-template-columns:1.1fr 1fr;gap:0">
+          <div class="post-cover" style="aspect-ratio:auto;min-height:260px;border-bottom:none;border-right:1px solid var(--border)">
+            <BlogCover hue={featured.cover?.hue} size={72} />
+          </div>
+          <div class="post-body" style="justify-content:center;padding:36px">
+            <div class="post-meta"><span class="tag">{featured.category}</span> · <time datetime={featured.date}>{formatDate(featured.date)}</time> · {featured.readingTime} min</div>
+            <h3 style="font-size:1.6rem">{featured.title}</h3>
+            <p class="post-excerpt">{featured.excerpt}</p>
+            <span class="post-readmore">Czytaj artykuł
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+            </span>
+          </div>
+        </div>
+      </a>
+
+      <!-- Pozostałe wpisy -->
+      <div class="grid grid-3">
+        {rest.map(p => (
+          <a href={`/blog/${p.slug}/`} class="post-card">
+            <div class="post-cover"><BlogCover hue={p.cover?.hue} size={48} /></div>
+            <div class="post-body">
+              <div class="post-meta"><span class="tag">{p.category}</span> · {p.readingTime} min</div>
+              <h3>{p.title}</h3>
+              <p class="post-excerpt">{p.excerpt}</p>
+              <span class="post-readmore">Czytaj artykuł
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+              </span>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <div class="nav-brand" style="margin-bottom:16px">
+            <span class="nav-brand-mark">B</span>
+            <span>BrightMind <span style="color:var(--fg-muted)">/ AI</span></span>
+          </div>
+          <p class="text-muted" style="font-size:0.9rem;max-width:320px">Profesjonalne wdrożenia AI B2B dla polskich firm. Automatyzacja procesów, agenci AI, doradztwo. Zgodne z RODO i NIS2.</p>
+        </div>
+        <div class="footer-col">
+          <h4>Usługi</h4>
+          <ul>
+            <li><a href="/#uslugi">Doradztwo AI dla Firm</a></li>
+            <li><a href="/#uslugi">Korepetycje AI</a></li>
+            <li><a href="/NIS2/">Wdrożenia NIS2</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Firma</h4>
+          <ul>
+            <li><a href="/o-mnie/">O mnie</a></li>
+            <li><a href="/ai-w-praktyce/">AI w Praktyce</a></li>
+            <li><a href="/blog/">Blog</a></li>
+            <li><a href="/#kontakt">Kontakt</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Kontakt</h4>
+          <ul style="font-size:0.85rem;color:var(--fg-muted)">
+            <li>Patryk Gliński</li>
+            <li><a href="mailto:kontakt@brightmind-solutions.com">kontakt@brightmind-solutions.com</a></li>
+            <li><a href="tel:+48730152161">+48 730 152 161</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2026 BrightMind AI Solutions. Wszystkie prawa zastrzeżone.</span>
+        <div style="display:flex;align-items:center;gap:20px">
+          <a href="https://www.youtube.com/@Neural_Update" target="_blank" rel="noopener noreferrer" style="display:inline-flex;align-items:center;gap:8px;padding:6px 14px;background:#ff0000;color:#fff;border-radius:var(--radius);font-weight:600;font-size:0.8rem;text-decoration:none">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="14" rx="3"/><polygon points="10 9.5 16 13 10 16.5 10 9.5"/></svg>
+            YouTube
+          </a>
+          <a href="/privacy-policy/" style="color:var(--fg-muted)">Polityka prywatności</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <CookieBanner client:load />
+</Layout>

--- a/src/pages/blog/lokalne-llm-dla-firm.astro
+++ b/src/pages/blog/lokalne-llm-dla-firm.astro
@@ -1,0 +1,109 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="lokalne-llm-dla-firm">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <ul>
+      <li><strong>Lokalny model LLM</strong> działa na infrastrukturze firmy — dane nigdy nie opuszczają Twojej sieci.</li>
+      <li>To realna przewaga przy <strong>RODO, NIS2 i tajemnicy przedsiębiorstwa</strong>, gdzie wysyłanie danych do chmury bywa problematyczne.</li>
+      <li>Modele open-source (Llama, Mistral, Qwen) osiągnęły jakość wystarczającą do większości zadań biznesowych.</li>
+      <li>Lokalny LLM opłaca się przy <strong>danych wrażliwych</strong> lub <strong>dużych, stałych wolumenach</strong>; do lekkich zastosowań API chmurowe bywa prostsze i tańsze.</li>
+    </ul>
+  </div>
+
+  <p>Przez ostatnie lata „korzystanie z AI” oznaczało w praktyce „wysyłanie danych do OpenAI, Anthropic albo Google”. Dla wielu firm to bariera nie do przejścia — kancelaria prawna, przychodnia, firma przetwarzająca dane osobowe klientów albo podmiot objęty NIS2 nie zawsze może pozwolić sobie na wysyłanie wrażliwych informacji poza własną infrastrukturę. Tu wkraczają <strong>lokalne modele LLM</strong>: sztuczna inteligencja, która działa w całości na sprzęcie firmy. W tym artykule wyjaśniam, kiedy to się naprawdę opłaca, czego wymaga i jak zacząć bez przepalania budżetu.</p>
+
+  <h2>Czym jest lokalny model LLM</h2>
+
+  <p>Lokalny (on-premise) model LLM to model językowy uruchomiony na serwerze lub stacji roboczej należącej do firmy, zamiast wywoływania zewnętrznego API. Zapytania, dokumenty i odpowiedzi pozostają w obrębie Twojej sieci. Dzięki rozwojowi modeli open-source — rodzin takich jak <strong>Llama</strong> (Meta), <strong>Mistral</strong> czy <strong>Qwen</strong> — oraz narzędzi ułatwiających ich uruchamianie (np. <a href="https://ollama.com/" target="_blank" rel="noopener noreferrer">Ollama</a> czy <a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noopener noreferrer">llama.cpp</a>), wdrożenie własnego modelu jest dziś osiągalne także dla średniej firmy, a nie tylko korporacji z działem badawczym.</p>
+
+  <h2>Główna przewaga: prywatność i zgodność</h2>
+
+  <p>To najczęstszy powód, dla którego firmy w ogóle rozważają lokalny model:</p>
+
+  <ul>
+    <li><strong>Dane nie opuszczają firmy.</strong> Nie wysyłasz dokumentów do zewnętrznego dostawcy, więc znika cała klasa pytań o przekazywanie danych do podmiotów trzecich i poza EOG.</li>
+    <li><strong>Łatwiejsza zgodność z RODO.</strong> Pełna kontrola nad tym, gdzie i jak długo przetwarzane są dane osobowe.</li>
+    <li><strong>Wsparcie dla NIS2.</strong> Mniejsza powierzchnia ataku i pełna kontrola nad łańcuchem przetwarzania to argumenty, które dobrze wyglądają w analizie ryzyka.</li>
+    <li><strong>Ochrona tajemnicy przedsiębiorstwa.</strong> Kod, umowy, dane finansowe i know-how zostają u Ciebie.</li>
+  </ul>
+
+  <div class="callout">
+    <p><strong>Połączenie z automatyzacją:</strong> lokalny model w parze z n8n self-hosted daje przepływ AI, w którym wrażliwe dane nie trafiają do żadnej chmury — od wyzwalacza, przez analizę modelem, po zapis wyniku. Dla branż regulowanych to często jedyna akceptowalna architektura.</p>
+  </div>
+
+  <h2>Pozostałe korzyści</h2>
+
+  <ul>
+    <li><strong>Przewidywalny koszt.</strong> Zamiast płacić za każdy token, ponosisz stały koszt sprzętu i energii — przy dużych wolumenach to się zwraca.</li>
+    <li><strong>Brak limitów zapytań i niezależność.</strong> Nie dotyczą Cię limity API ani zmiany cennika czy polityki dostawcy.</li>
+    <li><strong>Pełna personalizacja.</strong> Model można dostroić (fine-tuning) do języka i specyfiki Twojej branży.</li>
+    <li><strong>Działanie offline.</strong> System działa nawet bez dostępu do internetu, co bywa istotne w środowiskach odizolowanych.</li>
+  </ul>
+
+  <h2>Czego wymaga lokalny model — realia sprzętowe</h2>
+
+  <p>Najważniejszy zasób to <strong>pamięć karty graficznej (VRAM)</strong> — to ona głównie decyduje, jak duży model uruchomisz. Z grubsza:</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Rozmiar modelu</th><th>Typowe zastosowanie</th><th>Wymagania (orientacyjnie)</th></tr></thead>
+      <tbody>
+        <tr><td>Małe (≈3–8 mld parametrów)</td><td>Klasyfikacja, ekstrakcja, proste odpowiedzi</td><td>Wydajny desktop z GPU lub nawet dobry CPU</td></tr>
+        <tr><td>Średnie (≈8–14 mld)</td><td>Streszczenia, analiza dokumentów, asystent</td><td>GPU z większą ilością VRAM</td></tr>
+        <tr><td>Duże (≈30–70 mld)</td><td>Złożone rozumowanie, wymagające zadania</td><td>Serwer z mocnym GPU / wieloma GPU</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>Pomaga tu <strong>kwantyzacja</strong> — technika zmniejszania zapotrzebowania na pamięć kosztem minimalnej utraty jakości, która pozwala uruchomić większe modele na skromniejszym sprzęcie. Dzięki niej wiele zastosowań biznesowych obsłużysz modelem średniej wielkości na pojedynczej, rozsądnej karcie.</p>
+
+  <h2>Kiedy lokalny LLM bije API chmurowe — i kiedy nie</h2>
+
+  <h3>Lokalny model wygrywa, gdy:</h3>
+  <ul>
+    <li>przetwarzasz dane wrażliwe (osobowe, medyczne, prawne, objęte tajemnicą),</li>
+    <li>masz duży, stały wolumen zapytań,</li>
+    <li>podlegasz wymogom zgodności wymuszającym kontrolę nad danymi,</li>
+    <li>zależy Ci na niezależności od dostawcy i przewidywalnych kosztach.</li>
+  </ul>
+
+  <h3>API chmurowe wygrywa, gdy:</h3>
+  <ul>
+    <li>chcesz wystartować od zaraz, bez inwestycji w sprzęt,</li>
+    <li>Twoje wolumeny są niskie lub nieregularne,</li>
+    <li>potrzebujesz absolutnie najwyższej jakości rozumowania flagowych modeli,</li>
+    <li>dane nie są szczególnie wrażliwe.</li>
+  </ul>
+
+  <blockquote>W praktyce wiele firm stosuje model hybrydowy: lokalny LLM do wrażliwych i masowych zadań, a chmurowe API do pojedynczych, najtrudniejszych przypadków wymagających najmocniejszego modelu.</blockquote>
+
+  <h2>Jak zacząć — bezpieczna ścieżka</h2>
+
+  <ol>
+    <li><strong>Wybierz jeden konkretny proces.</strong> Najlepiej taki z danymi wrażliwymi, gdzie chmura jest problemem — np. wstępna analiza umów czy klasyfikacja zgłoszeń.</li>
+    <li><strong>Przetestuj na istniejącym sprzęcie.</strong> Zacznij od małego modelu uruchomionego narzędziem typu Ollama, żeby zweryfikować jakość na Twoich danych, zanim kupisz GPU.</li>
+    <li><strong>Zmierz jakość i wydajność.</strong> Sprawdź, czy mniejszy model wystarcza — bardzo często tak.</li>
+    <li><strong>Dobierz sprzęt do potwierdzonych potrzeb.</strong> Inwestuj w GPU dopiero, gdy znasz realny rozmiar modelu i wolumen.</li>
+    <li><strong>Wepnij model w bezpieczny przepływ.</strong> Połącz go z n8n self-hosted i kontrolą dostępu, by całość była zgodna i audytowalna.</li>
+  </ol>
+
+  <h2>Najczęstsze pytania</h2>
+
+  <h3>Czy lokalny model dorównuje jakością ChatGPT?</h3>
+  <p>Do większości zadań biznesowych — tak. Czołowe modele open-source średniej wielkości spokojnie obsługują streszczenia, ekstrakcję danych, klasyfikację czy asystę. Do najbardziej wymagającego rozumowania flagowe modele chmurowe wciąż potrafią mieć przewagę.</p>
+
+  <h3>Czy to drogie?</h3>
+  <p>Koszt początkowy to przede wszystkim sprzęt (GPU). Przy dużych wolumenach inwestycja zwraca się względem rosnących opłat za API. Przy małych — chmura bywa tańsza. Dlatego decyzję zawsze opieram na realnym wolumenie i wrażliwości danych.</p>
+
+  <h3>Czy potrzebuję zespołu data science?</h3>
+  <p>Nie do uruchomienia. Dzisiejsze narzędzia mocno upraszczają wdrożenie gotowych modeli. Zespół badawczy bywa potrzebny dopiero przy zaawansowanym fine-tuningu, którego większość firm na starcie nie wymaga.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> Lokalne modele LLM przestały być ciekawostką dla korporacji — to dziś praktyczny sposób, by korzystać z AI bez wynoszenia danych poza firmę. Opłacają się szczególnie przy danych wrażliwych i dużych wolumenach, zwłaszcza w branżach pod RODO i NIS2. Zastanawiasz się, czy lokalny model pasuje do Twoich procesów? <a href="/#kontakt">Umów bezpłatną konsultację</a> — ocenimy, czy w Twoim przypadku wygra chmura, lokalny model, czy hybryda.</p>
+
+</BlogLayout>

--- a/src/pages/blog/n8n-vs-zapier-automatyzacja-dla-firm.astro
+++ b/src/pages/blog/n8n-vs-zapier-automatyzacja-dla-firm.astro
@@ -1,0 +1,93 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="n8n-vs-zapier-automatyzacja-dla-firm">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <ul>
+      <li><strong>Zapier</strong> wygrywa prostotą i liczbą gotowych integracji — najlepszy na szybki start bez własnej infrastruktury.</li>
+      <li><strong>n8n</strong> wygrywa kontrolą nad danymi (self-hosting), elastycznością i kosztem przy dużej liczbie operacji.</li>
+      <li>Dla firm przetwarzających <strong>dane wrażliwe</strong> lub działających pod <strong>RODO/NIS2</strong> n8n self-hosted jest zwykle bezpieczniejszym wyborem.</li>
+      <li>To nie jest wybór „na zawsze” — wiele firm zaczyna od Zapiera i migruje do n8n, gdy rosną wolumeny.</li>
+    </ul>
+  </div>
+
+  <p>Gdy firma decyduje się zautomatyzować procesy, prędzej czy później staje przed pytaniem: <strong>n8n czy Zapier?</strong> Oba narzędzia łączą aplikacje i przenoszą dane między nimi bez pisania kodu, oba potrafią wpleść AI w przepływy pracy — ale ich filozofia, model kosztów i podejście do prywatności są fundamentalnie różne. W tym artykule porównuję je tak, jak patrzę na to przy realnych wdrożeniach B2B: nie „które jest lepsze”, tylko „które jest lepsze dla Ciebie”.</p>
+
+  <h2>Czym właściwie są te narzędzia</h2>
+
+  <p><strong>Zapier</strong> to dojrzała platforma SaaS działająca w chmurze dostawcy. Łączysz aplikacje (tzw. „Zaps”), wybierasz wyzwalacz i akcje, a całość działa na serwerach Zapiera. Siłą są tysiące gotowych integracji i bardzo niski próg wejścia.</p>
+
+  <p><strong>n8n</strong> to platforma automatyzacji typu „fair-code”, którą możesz uruchomić w chmurze dostawcy <em>albo</em> na własnym serwerze (self-hosting). Pracujesz na wizualnym płótnie węzłów (nodes), masz dostęp do logiki warunkowej, pętli i własnego kodu, a dane mogą nigdy nie opuścić Twojej infrastruktury. Szczegóły modelu licencyjnego opisuje <a href="https://docs.n8n.io/" target="_blank" rel="noopener noreferrer">dokumentacja n8n</a>.</p>
+
+  <h2>Porównanie po kluczowych kryteriach</h2>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Kryterium</th><th>Zapier</th><th>n8n</th></tr></thead>
+      <tbody>
+        <tr><td>Próg wejścia</td><td>Bardzo niski</td><td>Średni (zwłaszcza self-host)</td></tr>
+        <tr><td>Gotowe integracje</td><td>Tysiące</td><td>Setki + uniwersalne HTTP/kod</td></tr>
+        <tr><td>Hosting własny</td><td>Nie</td><td>Tak</td></tr>
+        <tr><td>Kontrola nad danymi</td><td>Dane w chmurze Zapiera</td><td>Pełna (self-host)</td></tr>
+        <tr><td>Model kosztów</td><td>Abonament rosnący z liczbą zadań</td><td>Stały koszt serwera (self-host)</td></tr>
+        <tr><td>Złożona logika</td><td>Ograniczona</td><td>Bardzo elastyczna</td></tr>
+        <tr><td>Krzywa uczenia</td><td>Łagodna</td><td>Stromsza</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Koszty — gdzie naprawdę się rozjeżdżają</h2>
+
+  <p>Zapier rozlicza się głównie od <strong>liczby wykonanych zadań</strong>. Przy małej automatyzacji jest tani, ale koszt rośnie liniowo z wolumenem — przy tysiącach operacji miesięcznie rachunek potrafi zaskoczyć. n8n w modelu self-hosted ma <strong>stały koszt serwera</strong> niezależny od liczby wykonań: czy przetworzysz 1000, czy 100 000 operacji, płacisz za tę samą maszynę.</p>
+
+  <blockquote>Reguła kciuka: przy niskim wolumenie i kilku prostych integracjach Zapier wychodzi taniej całościowo. Przy dużym wolumenie albo wielu złożonych przepływach n8n self-hosted zwykle wygrywa kosztowo — i to wyraźnie.</blockquote>
+
+  <h2>Prywatność danych — często decydujące kryterium</h2>
+
+  <p>To obszar, w którym różnica jest największa i najczęściej przesądza o wyborze w B2B. W Zapierze dane przepływają przez infrastrukturę dostawcy w chmurze. Dla wielu zastosowań to nie problem. Ale jeśli przetwarzasz <strong>dane osobowe, dokumenty prawne, dane medyczne czy informacje objęte tajemnicą przedsiębiorstwa</strong>, wysyłanie ich przez zewnętrzny SaaS rodzi pytania o zgodność z RODO, a w niektórych branżach z NIS2.</p>
+
+  <div class="callout">
+    <p><strong>Dlatego dla wrażliwych procesów rekomenduję n8n self-hosted:</strong> dane nie opuszczają Twojej infrastruktury, masz pełną kontrolę nad logami i retencją, a w razie audytu możesz wykazać, gdzie i jak są przetwarzane. W połączeniu z lokalnym modelem LLM otrzymujesz przepływ AI, w którym wrażliwe informacje w ogóle nie trafiają do chmury.</p>
+  </div>
+
+  <h2>AI w przepływach — oba dają radę, inaczej</h2>
+
+  <p>Zarówno Zapier, jak i n8n potrafią wywoływać modele językowe w ramach przepływu — np. streścić zgłoszenie, sklasyfikować e-mail, wygenerować odpowiedź. Zapier oferuje to w wygodny, „klikalny” sposób. n8n daje większą kontrolę: możesz budować wieloetapowych agentów, łączyć modele chmurowe z lokalnymi i precyzyjnie sterować tym, które dane trafiają do którego modelu. Dla zaawansowanych scenariuszy AI ta elastyczność bywa kluczowa.</p>
+
+  <h2>Który wybrać — konkretne scenariusze</h2>
+
+  <h3>Wybierz Zapier, jeśli…</h3>
+  <ul>
+    <li>chcesz uruchomić automatyzację w jeden dzień, bez własnego serwera,</li>
+    <li>łączysz popularne aplikacje SaaS w proste przepływy,</li>
+    <li>Twój wolumen operacji jest niski lub umiarkowany,</li>
+    <li>nie przetwarzasz danych szczególnie wrażliwych.</li>
+  </ul>
+
+  <h3>Wybierz n8n, jeśli…</h3>
+  <ul>
+    <li>zależy Ci na pełnej kontroli nad danymi (RODO/NIS2),</li>
+    <li>masz duży wolumen operacji i chcesz przewidywalny, stały koszt,</li>
+    <li>budujesz złożoną logikę lub agentów AI,</li>
+    <li>chcesz łączyć modele lokalne i chmurowe w jednym przepływie.</li>
+  </ul>
+
+  <h2>Najczęstsze pytania</h2>
+
+  <h3>Czy można zacząć od Zapiera i przejść na n8n?</h3>
+  <p>Tak i to częsta ścieżka. Firmy zaczynają od Zapiera, by szybko udowodnić wartość automatyzacji, a gdy rosną wolumeny lub pojawiają się wymogi prywatności — migrują kluczowe przepływy do n8n self-hosted.</p>
+
+  <h3>Czy n8n self-hosted jest trudny w utrzymaniu?</h3>
+  <p>Wymaga serwera i podstawowej administracji, ale dla większości MŚP to jednorazowa konfiguracja plus okazjonalne aktualizacje. Koszt utrzymania zwykle i tak jest niższy niż rosnący abonament SaaS przy większej skali.</p>
+
+  <h3>Co z innymi narzędziami, np. Make?</h3>
+  <p>Make to kolejna popularna opcja plasująca się między Zapierem a n8n pod względem elastyczności. Logika wyboru jest jednak ta sama: zacznij od pytań o wolumen, prywatność danych i złożoność logiki — narzędzie dobierzesz na końcu.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> n8n i Zapier rozwiązują ten sam problem z różnych stron. Zapier kupujesz za prostotę i czas, n8n — za kontrolę i koszt przy skali. Dla firm dbających o prywatność danych i działających pod NIS2 częściej rekomenduję n8n self-hosted, zwłaszcza w parze z lokalnym LLM. Nie wiesz, co pasuje do Twoich procesów? <a href="/#kontakt">Umów bezpłatną konsultację</a> — dobierzemy narzędzie do realnego scenariusza, a nie odwrotnie.</p>
+
+</BlogLayout>

--- a/src/pages/blog/nis2-dla-msp-checklista-90-dni.astro
+++ b/src/pages/blog/nis2-dla-msp-checklista-90-dni.astro
@@ -1,0 +1,243 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="nis2-dla-msp-checklista-90-dni">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <ul>
+      <li>Dyrektywa <strong>NIS2</strong> obejmuje w Polsce tysiące firm, które nigdy wcześniej nie podlegały regulacjom cyberbezpieczeństwa — także wiele <strong>małych i średnich przedsiębiorstw</strong> z 18 sektorów.</li>
+      <li>Za brak zgodności grożą kary do <strong>10 mln euro lub 2% rocznego obrotu</strong> oraz osobista odpowiedzialność członków zarządu.</li>
+      <li>Realne wdrożenie w MŚP da się przeprowadzić w <strong>90 dni</strong> — pod warunkiem, że pracujesz według planu, a nie gasisz pożary.</li>
+      <li>Poniżej znajdziesz checklistę podzieloną na trzy fazy po 30 dni: <strong>analiza luki → polityki i zabezpieczenia → testy i raportowanie</strong>.</li>
+    </ul>
+  </div>
+
+  <p>Jeszcze dwa lata temu dyrektywa o bezpieczeństwie sieci i informacji była tematem wyłącznie dla banków, operatorów telekomunikacyjnych i dużych dostawców energii. <strong>NIS2 zmienia tę logikę całkowicie.</strong> Nowa dyrektywa rozszerza katalog podmiotów objętych obowiązkami na 18 sektorów i — co kluczowe dla czytelników tego bloga — przestaje patrzeć wyłącznie na wielkość firmy. Liczy się to, <em>co</em> robisz, a nie tylko <em>jak duży</em> jesteś.</p>
+
+  <p>Jeśli prowadzisz średniej wielkości firmę produkcyjną, software house, hurtownię, firmę z branży spożywczej, podmiot świadczący usługi cyfrowe albo dostawcę dla sektora zdrowia — istnieje realna szansa, że NIS2 dotyczy właśnie Ciebie. A termin na dostosowanie nie jest abstrakcyjną przyszłością. W tym artykule pokazuję, jak przejść od „nie wiem, czy mnie to dotyczy” do udokumentowanej zgodności w <strong>90 dni</strong>, bez budżetu rzędu setek tysięcy złotych na konsulting korporacyjny.</p>
+
+  <h2>Czym właściwie jest NIS2 i kogo obejmuje</h2>
+
+  <p>NIS2 (dyrektywa <a href="https://eur-lex.europa.eu/legal-content/PL/TXT/?uri=CELEX%3A32022L2555" target="_blank" rel="noopener noreferrer">UE 2022/2555</a>) to unijna regulacja, która zastąpiła pierwotną dyrektywę NIS z 2016 roku. Jej celem jest podniesienie poziomu cyberbezpieczeństwa w całej Unii poprzez nałożenie konkretnych obowiązków na podmioty uznane za istotne dla funkcjonowania gospodarki i społeczeństwa. W Polsce dyrektywa jest wdrażana poprzez nowelizację <strong>ustawy o krajowym systemie cyberbezpieczeństwa (KSC)</strong> — to właśnie ten akt określa szczegółowe wymagania, którym musisz sprostać.</p>
+
+  <p>Dyrektywa dzieli objęte podmioty na dwie kategorie:</p>
+
+  <ul>
+    <li><strong>Podmioty kluczowe (essential)</strong> — m.in. energia, transport, bankowość, infrastruktura rynku finansowego, ochrona zdrowia, woda pitna, infrastruktura cyfrowa, administracja publiczna.</li>
+    <li><strong>Podmioty ważne (important)</strong> — m.in. usługi pocztowe i kurierskie, gospodarka odpadami, produkcja i dystrybucja chemikaliów, produkcja żywności, produkcja (w tym wyrobów medycznych, elektroniki, maszyn, pojazdów), dostawcy usług cyfrowych, badania naukowe.</li>
+  </ul>
+
+  <p>Różnica między kategoriami przekłada się na intensywność nadzoru i wysokość kar, ale <strong>zakres podstawowych obowiązków technicznych i organizacyjnych jest zbliżony</strong>. Z perspektywy MŚP najważniejsze jest jedno: jeśli działasz w jednym z wymienionych sektorów i zatrudniasz co najmniej 50 osób lub masz obrót powyżej 10 mln euro, najprawdopodobniej podlegasz dyrektywie. Ale uwaga — istnieją wyjątki, w których próg wielkości nie obowiązuje (np. dostawcy usług DNS, rejestry domen, niektórzy dostawcy infrastruktury krytycznej). Pełną klasyfikację sektorów znajdziesz w materiałach <a href="https://www.gov.pl/web/cyfryzacja" target="_blank" rel="noopener noreferrer">Ministerstwa Cyfryzacji</a> oraz w wytycznych europejskiej agencji <a href="https://www.enisa.europa.eu/topics/nis-directive" target="_blank" rel="noopener noreferrer">ENISA</a>.</p>
+
+  <div class="callout">
+    <p><strong>Najczęstszy błąd:</strong> „Jesteśmy małą firmą, więc nas to nie dotyczy”. NIS2 obejmuje także średnie przedsiębiorstwa, a w niektórych przypadkach mniejsze podmioty świadczące krytyczne usługi. Pierwszym krokiem nie jest zakup oprogramowania — jest nim <strong>rzetelne ustalenie, czy i jako jaki podmiot podlegasz dyrektywie.</strong></p>
+  </div>
+
+  <h2>Co grozi za brak zgodności</h2>
+
+  <p>To nie jest regulacja „na papierze”. NIS2 wprowadza realne sankcje:</p>
+
+  <ul>
+    <li>Dla podmiotów kluczowych — kary do <strong>10 mln euro lub 2% całkowitego rocznego światowego obrotu</strong> (stosuje się kwotę wyższą).</li>
+    <li>Dla podmiotów ważnych — kary do <strong>7 mln euro lub 1,4% obrotu</strong>.</li>
+    <li><strong>Osobista odpowiedzialność kierownictwa</strong> — organy nadzoru mogą czasowo zakazać pełnienia funkcji zarządczych osobom odpowiedzialnym za rażące zaniedbania.</li>
+    <li>Obowiązek zatwierdzania i nadzorowania środków zarządzania ryzykiem przez <strong>zarząd</strong> — to nie jest już temat „dla działu IT”.</li>
+  </ul>
+
+  <p>Ten ostatni punkt zmienia wszystko. NIS2 świadomie przenosi odpowiedzialność na poziom zarządu, bo doświadczenie pokazało, że cyberbezpieczeństwo traktowane jako koszt techniczny jest spychane na koniec listy priorytetów. Teraz członek zarządu, który zignoruje obowiązki, ryzykuje osobiście.</p>
+
+  <h2>Plan na 90 dni — przegląd</h2>
+
+  <p>Wdrożenie podzieliłem na trzy 30-dniowe fazy. Taki rytm sprawdza się w MŚP, bo pozwala pokazać postęp zarządowi co miesiąc i nie blokuje bieżącej działalności. Oto mapa:</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th>Faza</th><th>Dni</th><th>Cel</th><th>Efekt</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>Faza 1 — Diagnoza</strong></td><td>1–30</td><td>Ustalenie statusu, inwentaryzacja, analiza luki</td><td>Rejestr aktywów + raport luki</td></tr>
+        <tr><td><strong>Faza 2 — Wdrożenie</strong></td><td>31–60</td><td>Polityki, zabezpieczenia techniczne, szkolenia</td><td>Komplet polityk + wdrożone kontrole</td></tr>
+        <tr><td><strong>Faza 3 — Weryfikacja</strong></td><td>61–90</td><td>Testy, procedury incydentów, rejestracja</td><td>Plan ciągłości + gotowość do audytu</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Faza 1 (dni 1–30): diagnoza i analiza luki</h2>
+
+  <p>Nie da się naprawić czegoś, czego nie zmierzyłeś. Pierwsze 30 dni poświęcasz na zrozumienie, gdzie jesteś — bez kupowania jakichkolwiek narzędzi.</p>
+
+  <h3>Checklista fazy 1</h3>
+
+  <ul>
+    <li><strong>Ustal status podmiotu.</strong> Zweryfikuj swój sektor i wielkość względem kryteriów ustawy KSC. Udokumentuj wnioski (kategoria kluczowy/ważny lub uzasadnienie wyłączenia). Ten dokument to podstawa — od niego zależy zakres reszty prac.</li>
+    <li><strong>Wyznacz osobę odpowiedzialną.</strong> NIS2 wymaga jasnej odpowiedzialności. W MŚP nie musisz zatrudniać CISO — wystarczy wyznaczona osoba (wewnętrzna lub zewnętrzny doradca) z mandatem zarządu.</li>
+    <li><strong>Zinwentaryzuj aktywa.</strong> Spisz wszystkie systemy, aplikacje, serwery, urządzenia, konta w chmurze i przepływy danych. Nie możesz chronić zasobów, o których nie wiesz. Wystarczy arkusz: nazwa zasobu, właściciel, krytyczność, dane jakie przetwarza.</li>
+    <li><strong>Zmapuj dostawców i łańcuch dostaw.</strong> NIS2 kładzie duży nacisk na bezpieczeństwo łańcucha dostaw. Wypisz kluczowych dostawców IT i usług — to oni są dziś najczęstszym wektorem ataku.</li>
+    <li><strong>Przeprowadź analizę luki (gap analysis).</strong> Porównaj stan obecny z wymaganiami art. 21 dyrektywy (środki zarządzania ryzykiem). Dla każdego wymogu oznacz: spełnione / częściowo / brak.</li>
+    <li><strong>Oceń ryzyko.</strong> Dla najważniejszych aktywów oszacuj prawdopodobieństwo i skutek incydentu. Nie potrzebujesz zaawansowanej metodyki — wystarczy macierz 3×3 i lista priorytetów.</li>
+  </ul>
+
+  <p>Wymagania art. 21, do których będziesz się odnosić, obejmują m.in.: politykę analizy ryzyka, obsługę incydentów, ciągłość działania i kopie zapasowe, bezpieczeństwo łańcucha dostaw, bezpieczeństwo przy nabywaniu i utrzymaniu systemów, ocenę skuteczności środków, podstawową cyberhigienę i szkolenia, kryptografię, kontrolę dostępu i zarządzanie aktywami oraz uwierzytelnianie wieloskładnikowe. Pełny katalog opisuje <a href="https://eur-lex.europa.eu/legal-content/PL/TXT/?uri=CELEX%3A32022L2555" target="_blank" rel="noopener noreferrer">tekst dyrektywy</a>, a praktyczne wskazówki — przewodniki ENISA.</p>
+
+  <blockquote>Analiza luki to nie biurokracja. To moment, w którym zwykle okazuje się, że firma ma backupy, których nikt nigdy nie odtworzył, oraz konta administratorów po pracownikach sprzed dwóch lat. Sam ten audyt często zwraca koszty wdrożenia.</blockquote>
+
+  <h2>Faza 2 (dni 31–60): polityki i zabezpieczenia techniczne</h2>
+
+  <p>Mając raport luki, wiesz dokładnie, co naprawić. Druga faza to wdrażanie — równolegle na poziomie organizacyjnym (polityki) i technicznym (kontrole).</p>
+
+  <h3>Warstwa organizacyjna — polityki</h3>
+
+  <ul>
+    <li><strong>Polityka bezpieczeństwa informacji</strong> — dokument nadrzędny, zatwierdzony przez zarząd, opisujący podejście firmy do ochrony danych i systemów.</li>
+    <li><strong>Polityka zarządzania ryzykiem</strong> — jak identyfikujecie, oceniacie i ograniczacie ryzyka; jak często przeglądacie ocenę.</li>
+    <li><strong>Procedura obsługi incydentów</strong> — kto, co i w jakiej kolejności robi, gdy dojdzie do naruszenia (do tego wrócę w fazie 3).</li>
+    <li><strong>Polityka kontroli dostępu</strong> — zasada minimalnych uprawnień, przegląd kont, rozdzielenie ról.</li>
+    <li><strong>Polityka kopii zapasowych i ciągłości działania</strong> — co, jak często i gdzie backupujecie oraz jak przywracacie działanie.</li>
+    <li><strong>Wymagania bezpieczeństwa wobec dostawców</strong> — klauzule w umowach, weryfikacja kluczowych partnerów.</li>
+  </ul>
+
+  <div class="callout">
+    <p><strong>Wskazówka praktyczna:</strong> polityki nie muszą być stustronicowe. Lepsza jest zwięzła, faktycznie przestrzegana polityka na 3 strony niż imponujący dokument, którego nikt nie czytał. Organ nadzoru ocenia, czy środki są <em>realnie stosowane</em>, a nie ich objętość.</p>
+  </div>
+
+  <h3>Warstwa techniczna — kontrole</h3>
+
+  <ul>
+    <li><strong>Uwierzytelnianie wieloskładnikowe (MFA)</strong> na wszystkich kontach administracyjnych, poczcie i dostępie zdalnym. To pojedyncza zmiana o najwyższym stosunku efektu do kosztu.</li>
+    <li><strong>Zarządzanie aktualizacjami</strong> — proces łatania systemów i aplikacji; szczególnie krytycznych podatności.</li>
+    <li><strong>Segmentacja sieci i kontrola dostępu</strong> — oddzielenie systemów krytycznych, ograniczenie ruchu.</li>
+    <li><strong>Szyfrowanie</strong> danych wrażliwych w spoczynku i w tranzycie.</li>
+    <li><strong>Kopie zapasowe w modelu 3-2-1</strong> (trzy kopie, dwa nośniki, jedna poza siedzibą) i — co najważniejsze — <strong>przetestowane odtwarzanie</strong>.</li>
+    <li><strong>Logowanie i monitoring</strong> — zbieranie logów z kluczowych systemów, aby w razie incydentu dało się ustalić, co się stało.</li>
+    <li><strong>Ochrona stacji końcowych</strong> — aktualne EDR/antywirus, kontrola urządzeń.</li>
+  </ul>
+
+  <h3>Cyberhigiena i szkolenia</h3>
+
+  <p>Dyrektywa wprost wymaga podstawowych szkoleń z cyberhigieny — także dla zarządu. Phishing wciąż odpowiada za większość udanych włamań w sektorze MŚP, a żadne narzędzie nie zastąpi pracownika, który rozpozna podejrzaną wiadomość. Zaplanuj krótkie, regularne szkolenia i co najmniej jedną symulację phishingu w roku.</p>
+
+  <p>To również obszar, w którym <strong>AI realnie pomaga</strong>: lokalne modele LLM mogą analizować logi, wstępnie klasyfikować alerty i przygotowywać materiały szkoleniowe bez wysyłania wrażliwych danych firmy do chmury. O tym, kiedy lokalny model bije API chmurowe, piszę szerzej w osobnym artykule na tym blogu.</p>
+
+  <h2>Faza 3 (dni 61–90): testy, incydenty i raportowanie</h2>
+
+  <p>Trzecia faza zamienia „mamy polityki” w „wiemy, że to działa”. To także moment dopełnienia obowiązków formalnych.</p>
+
+  <h3>Procedura zgłaszania incydentów — serce NIS2</h3>
+
+  <p>NIS2 wprowadza rygorystyczne, wieloetapowe terminy zgłaszania poważnych incydentów do właściwego <strong>CSIRT</strong> (w Polsce m.in. <a href="https://csirt.gov.pl/" target="_blank" rel="noopener noreferrer">CSIRT GOV</a> oraz <a href="https://cert.pl/" target="_blank" rel="noopener noreferrer">CERT Polska / CSIRT NASK</a>):</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Etap</th><th>Termin</th><th>Zawartość</th></tr></thead>
+      <tbody>
+        <tr><td>Wczesne ostrzeżenie</td><td>do 24 godzin</td><td>Sygnał, że doszło do poważnego incydentu; podejrzenie działania bezprawnego/transgranicznego</td></tr>
+        <tr><td>Zgłoszenie incydentu</td><td>do 72 godzin</td><td>Wstępna ocena: charakter, dotkliwość, wskaźniki kompromitacji</td></tr>
+        <tr><td>Raport końcowy</td><td>do 1 miesiąca</td><td>Pełny opis, przyczyna źródłowa, zastosowane i planowane środki</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>Dlatego procedura incydentów nie może być teoretyczna. W ciągu pierwszej doby od wykrycia poważnego incydentu firma musi wiedzieć, <em>kto</em> podejmuje decyzję o zgłoszeniu, <em>jak</em> kontaktuje się z CSIRT i <em>gdzie</em> znajdują się potrzebne informacje. Przygotuj jednostronicową kartę incydentu z rolami, telefonami i krokami — to ona uratuje Cię pod presją.</p>
+
+  <h3>Checklista fazy 3</h3>
+
+  <ul>
+    <li><strong>Przeprowadź test odtworzenia z backupu.</strong> Realnie przywróć wybrany system z kopii i zmierz czas. To jedyny dowód, że Twoja ciągłość działania nie jest fikcją.</li>
+    <li><strong>Wykonaj ćwiczenie incydentowe (tabletop).</strong> Zbierz zespół i przejdźcie scenariusz ataku ransomware krok po kroku według procedury. Zanotuj, gdzie procedura się sypie, i popraw ją.</li>
+    <li><strong>Zarejestruj podmiot.</strong> Dopełnij obowiązku rejestracji we właściwym organie zgodnie z ustawą KSC (terminy i tryb określa polska ustawa wdrażająca).</li>
+    <li><strong>Zatwierdź środki na poziomie zarządu.</strong> Udokumentuj, że zarząd zapoznał się z oceną ryzyka i zatwierdził środki — to wprost wymagane przez dyrektywę.</li>
+    <li><strong>Ustal cykl przeglądu.</strong> Wyznacz daty kwartalnych przeglądów ryzyka i rocznej aktualizacji polityk. Zgodność to proces, nie jednorazowy projekt.</li>
+    <li><strong>Przygotuj dokumentację do audytu.</strong> Zbierz w jednym miejscu: raport luki, rejestr aktywów, polityki, dowody szkoleń, logi testów. W razie kontroli organu nadzoru musisz to <em>pokazać</em>.</li>
+  </ul>
+
+  <h2>Bezpieczeństwo łańcucha dostaw — sektor, który zwykle umyka</h2>
+
+  <p>Jednym z najważniejszych — i najczęściej niedocenianych — elementów NIS2 jest <strong>bezpieczeństwo łańcucha dostaw</strong>. Dyrektywa wprost wymaga, byś uwzględniał podatności swoich dostawców oraz jakość ich praktyk bezpieczeństwa. Powód jest brutalnie praktyczny: większość głośnych incydentów ostatnich lat nie zaczęła się od włamania bezpośrednio do ofiary, lecz od przejęcia zaufanego dostawcy oprogramowania lub usług, przez którego napastnik wszedł „kuchennymi drzwiami”.</p>
+
+  <p>Dla MŚP nie oznacza to konieczności audytowania każdego kontrahenta. Oznacza to natomiast trzy konkretne działania:</p>
+
+  <ul>
+    <li><strong>Klasyfikację dostawców.</strong> Podziel partnerów na krytycznych (mają dostęp do Twoich systemów lub danych) i pozostałych. Energię skupiasz na tych pierwszych.</li>
+    <li><strong>Wymagania umowne.</strong> Wprowadź do umów z krytycznymi dostawcami klauzule dotyczące bezpieczeństwa, zgłaszania incydentów i prawa do informacji o stosowanych środkach.</li>
+    <li><strong>Okresowy przegląd.</strong> Raz w roku zweryfikuj, czy krytyczni dostawcy nadal spełniają oczekiwania — np. prosząc o certyfikaty lub wypełnienie krótkiej ankiety bezpieczeństwa.</li>
+  </ul>
+
+  <p>To także obszar, w którym Twoja własna zgodność staje się atutem handlowym: coraz częściej to <em>Twoi</em> więksi klienci, sami objęci NIS2, będą wymagać od Ciebie wykazania środków bezpieczeństwa. Wdrożenie dyrektywy przestaje być wtedy kosztem, a staje się warunkiem utrzymania kontraktów.</p>
+
+  <h2>Rola i odpowiedzialność zarządu</h2>
+
+  <p>Wspomniałem o tym wcześniej, ale temat jest na tyle istotny, że zasługuje na osobne omówienie. NIS2 świadomie zrywa z modelem, w którym cyberbezpieczeństwo jest „sprawą informatyków”. Dyrektywa nakłada na <strong>organy zarządzające</strong> dwa wyraźne obowiązki:</p>
+
+  <ul>
+    <li><strong>Zatwierdzanie środków zarządzania ryzykiem</strong> — zarząd musi formalnie przyjąć i nadzorować wdrożone środki, a nie jedynie „wiedzieć, że coś się dzieje”.</li>
+    <li><strong>Odbycie szkolenia</strong> — członkowie kierownictwa mają obowiązek uczestniczyć w szkoleniach pozwalających rozpoznawać ryzyka i oceniać praktyki zarządzania bezpieczeństwem.</li>
+  </ul>
+
+  <p>Za zaniedbania w tym zakresie odpowiedzialność jest osobista, a organ nadzoru może czasowo zakazać pełnienia funkcji zarządczych. W praktyce oznacza to, że projekt NIS2 musi mieć <strong>sponsora na poziomie zarządu</strong> — osobę, która podejmie decyzje, przydzieli budżet i podpisze dokumenty. Bez tego wdrożenie grzęźnie na etapie „ktoś powinien się tym zająć”.</p>
+
+  <div class="callout">
+    <p><strong>Praktyczna wskazówka:</strong> udokumentuj zaangażowanie zarządu od pierwszego dnia. Protokół z posiedzenia, na którym zarząd przyjął plan wdrożenia i ocenę ryzyka, to jeden z najważniejszych dowodów zgodności, a zarazem dokument, który najłatwiej zdobyć — wystarczy o nim pamiętać na starcie.</p>
+  </div>
+
+  <h2>Dokumentacja, którą musisz mieć</h2>
+
+  <p>W razie kontroli organ nadzoru nie ocenia Twoich intencji — ocenia dowody. Dlatego równolegle z wdrażaniem środków buduj „teczkę zgodności”. Minimalny zestaw dokumentów dla MŚP wygląda tak:</p>
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Dokument</th><th>Po co</th></tr></thead>
+      <tbody>
+        <tr><td>Ustalenie statusu podmiotu</td><td>Dowód, że poprawnie zaklasyfikowałeś firmę</td></tr>
+        <tr><td>Rejestr aktywów</td><td>Pokazuje, co i jak chronisz</td></tr>
+        <tr><td>Ocena ryzyka</td><td>Podstawa doboru środków</td></tr>
+        <tr><td>Komplet polityk</td><td>Warstwa organizacyjna zgodności</td></tr>
+        <tr><td>Procedura incydentów</td><td>Gotowość do zgłoszeń w terminach 24h/72h/miesiąc</td></tr>
+        <tr><td>Rejestr szkoleń</td><td>Dowód cyberhigieny, także dla zarządu</td></tr>
+        <tr><td>Dowody testów (backup, tabletop)</td><td>Potwierdzenie, że środki działają</td></tr>
+        <tr><td>Protokoły zarządu</td><td>Zatwierdzenie środków na właściwym szczeblu</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>Trzymaj te dokumenty w jednym, uporządkowanym miejscu i nadaj im daty oraz wersje. Audyt zgodności wygrywa lub przegrywa nie na poziomie technologii, lecz na poziomie tego, czy potrafisz <em>pokazać</em>, że robisz to, co deklarujesz.</p>
+
+  <h2>Najczęstsze błędy przy wdrażaniu NIS2</h2>
+
+  <ul>
+    <li><strong>Zaczynanie od zakupu narzędzi.</strong> Bez analizy luki kupujesz rozwiązania problemów, których możesz nie mieć, a pomijasz te realne.</li>
+    <li><strong>Polityki „z internetu”.</strong> Skopiowany szablon, którego nikt nie stosuje, jest gorszy niż jego brak — sugeruje pozorność działań.</li>
+    <li><strong>Pominięcie testów.</strong> Backup, którego nigdy nie odtworzono, i procedura, której nigdy nie przećwiczono, to fikcja, która ujawni się w najgorszym momencie.</li>
+    <li><strong>Traktowanie zgodności jako projektu jednorazowego.</strong> NIS2 wymaga cyklicznych przeglądów — bez ustalonego rytmu zgodność „wygasa” w kilka miesięcy.</li>
+    <li><strong>Zostawienie zarządu poza procesem.</strong> Bez decyzyjnego sponsora wdrożenie nie ma jak ruszyć z miejsca.</li>
+  </ul>
+
+  <h2>Ile to kosztuje w praktyce</h2>
+
+  <p>W MŚP gros wymagań NIS2 da się spełnić narzędziami, które firma już posiada (MFA w pakietach Microsoft 365 czy Google Workspace, wbudowane szyfrowanie, polityki w katalogu użytkowników). Największym kosztem nie jest software, lecz <strong>czas i kompetencje</strong> potrzebne do uporządkowania procesów oraz napisania polityk, które przejdą audyt. Dlatego rozsądny model dla średniej firmy to wsparcie doradcze przy diagnozie i politykach plus samodzielne wdrożenie kontroli technicznych. Szczegółowy rozkład kosztów wdrożeń (w tym AI wspierającego bezpieczeństwo) omawiam w artykule o kosztach AI w firmie B2B.</p>
+
+  <div class="callout">
+    <p><strong>Połączenie prawa i technologii ma tu znaczenie.</strong> NIS2 to regulacja na styku przepisów i cyberbezpieczeństwa. Jako radca prawny z certyfikatem Blue Team (HackerU) i Google Cloud Generative AI Leader patrzę na nią z obu stron — prawnej zgodności i realnej obrony systemów. To pozwala uniknąć dwóch skrajności: „papierowej” zgodności bez realnego bezpieczeństwa oraz dobrych zabezpieczeń bez dokumentacji, której wymaga organ nadzoru.</p>
+  </div>
+
+  <h2>Najczęstsze pytania o NIS2 w MŚP</h2>
+
+  <h3>Czy mała firma na pewno podlega NIS2?</h3>
+  <p>Zależy od sektora i wielkości. Większość mikrofirm jest wyłączona, ale średnie przedsiębiorstwa (od 50 osób lub 10 mln euro obrotu) w 18 sektorach zwykle podlegają. Niektóre podmioty świadczące krytyczne usługi cyfrowe podlegają niezależnie od wielkości. Status zawsze ustalaj indywidualnie i dokumentuj wniosek.</p>
+
+  <h3>Czy muszę zatrudnić specjalistę ds. bezpieczeństwa?</h3>
+  <p>Nie ma takiego wprost wymogu. Potrzebujesz jasno przypisanej odpowiedzialności i realnie stosowanych środków. W MŚP rolę tę często pełni wyznaczony pracownik wspierany przez zewnętrznego doradcę.</p>
+
+  <h3>Co jeśli nie zdążę w terminie ustawowym?</h3>
+  <p>Najgorsza strategia to bezczynność. Udokumentowany, realizowany plan naprawczy jest oceniany zupełnie inaczej niż brak jakichkolwiek działań. Zacznij od fazy 1 — sama analiza luki i przypisanie odpowiedzialności pokazują, że traktujesz obowiązki poważnie.</p>
+
+  <h3>Czy AI może pomóc w spełnieniu wymogów NIS2?</h3>
+  <p>Tak — w analizie logów, wstępnej klasyfikacji alertów, generowaniu i utrzymywaniu dokumentacji oraz szkoleniach. Dla danych wrażliwych rekomenduję rozwiązania lokalne (on-premise LLM), które nie wynoszą informacji poza infrastrukturę firmy, co samo w sobie wspiera zgodność.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> NIS2 nie jest powodem do paniki, ale nie jest też regulacją, którą można przeczekać. Realny plan na 90 dni — diagnoza, wdrożenie, weryfikacja — pozwala średniej firmie osiągnąć udokumentowaną zgodność bez korporacyjnego budżetu. Klucz to zacząć od rzetelnej analizy luki i pracować według checklisty, a nie reagować po incydencie. Jeśli chcesz, by ktoś przeszedł z Tobą tę ścieżkę od strony prawnej i technicznej jednocześnie — <a href="/NIS2/">zobacz, jak wygląda wdrożenie NIS2 w BrightMind</a> albo umów bezpłatną konsultację.</p>
+
+</BlogLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -146,6 +146,7 @@ const ldJson = [
         <a href="#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="#kontakt">Kontakt</a>
         <a href="/en/" class="lang-switch" aria-label="English version" style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border:1px solid var(--border);border-radius:var(--radius);font-size:0.8rem;color:var(--fg-muted);text-decoration:none">
@@ -587,6 +588,7 @@ const ldJson = [
           <ul>
             <li><a href="/o-mnie/">O mnie</a></li>
             <li><a href="/ai-w-praktyce/">AI w Praktyce</a></li>
+            <li><a href="/blog/">Blog</a></li>
             <li><a href="#cennik">Cennik</a></li>
             <li><a href="#kontakt">Kontakt</a></li>
           </ul>

--- a/src/pages/o-mnie.astro
+++ b/src/pages/o-mnie.astro
@@ -67,6 +67,7 @@ const credentials = [
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="/#kontakt">Kontakt</a>
         <a href="/en/about.html" class="lang-switch" aria-label="English version" style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border:1px solid var(--border);border-radius:var(--radius);font-size:0.8rem;color:var(--fg-muted);text-decoration:none">
@@ -184,6 +185,7 @@ const credentials = [
           <ul>
             <li><a href="/o-mnie/">O mnie</a></li>
             <li><a href="/ai-w-praktyce/">AI w Praktyce</a></li>
+            <li><a href="/blog/">Blog</a></li>
             <li><a href="/#kontakt">Kontakt</a></li>
           </ul>
         </div>

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -73,6 +73,7 @@ const ldJson = [
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/" class="active">Portfolio</a>
         <a href="/#kontakt">Kontakt</a>
         <a href="/#kontakt" class="nav-cta">Bezpłatna konsultacja →</a>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -21,6 +21,7 @@ import CookieBanner from '../components/CookieBanner.jsx';
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="/#kontakt">Kontakt</a>
         <a href="/#kontakt" class="nav-cta">Bezpłatna konsultacja →</a>

--- a/src/pages/success.astro
+++ b/src/pages/success.astro
@@ -21,6 +21,7 @@ import CookieBanner from '../components/CookieBanner.jsx';
         <a href="/#uslugi">Usługi</a>
         <a href="/NIS2/">NIS2</a>
         <a href="/ai-w-praktyce/">AI w Praktyce</a>
+        <a href="/blog/">Blog</a>
         <a href="/portfolio/">Portfolio</a>
         <a href="/#kontakt">Kontakt</a>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -454,3 +454,247 @@ a:hover { color: var(--accent-strong); }
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
+
+/* ============================================================
+   BLOG
+   ============================================================ */
+
+/* Blog listing cards */
+.post-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.2s;
+  height: 100%;
+}
+.post-card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+}
+.post-card a { color: inherit; }
+.post-cover {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  display: grid;
+  place-items: center;
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(ellipse 90% 80% at 30% 10%, var(--accent-soft), transparent 60%),
+    var(--bg-elev-2);
+  overflow: hidden;
+}
+.post-cover svg { color: var(--accent); opacity: 0.9; }
+.post-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--border-strong) 1px, transparent 1px);
+  background-size: 22px 22px;
+  opacity: 0.18;
+  pointer-events: none;
+}
+.post-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  flex: 1;
+}
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--fg-dim);
+  letter-spacing: 0.03em;
+}
+.post-card h3 {
+  font-size: 1.2rem;
+  line-height: 1.3;
+  letter-spacing: -0.02em;
+}
+.post-card:hover h3 { color: var(--accent); }
+.post-card .post-excerpt {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  flex: 1;
+}
+.post-readmore {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+/* Category tag */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  white-space: nowrap;
+}
+
+/* Article (single post) */
+.article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+.article-header { padding: 64px 0 40px; }
+.article-cover {
+  position: relative;
+  aspect-ratio: 21 / 9;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: grid;
+  place-items: center;
+  margin: 8px 0 40px;
+  background:
+    radial-gradient(ellipse 80% 70% at 25% 0%, var(--accent-soft), transparent 60%),
+    var(--bg-elev);
+  overflow: hidden;
+}
+.article-cover svg { color: var(--accent); width: 64px; height: 64px; }
+.article-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--border-strong) 1px, transparent 1px);
+  background-size: 24px 24px;
+  opacity: 0.16;
+}
+
+/* Prose typography for article bodies */
+.prose { font-size: 1.06rem; line-height: 1.8; color: var(--fg); }
+.prose > * + * { margin-top: 24px; }
+.prose h2 {
+  font-size: 1.7rem;
+  margin-top: 56px;
+  padding-top: 8px;
+  scroll-margin-top: 88px;
+}
+.prose h3 {
+  font-size: 1.25rem;
+  margin-top: 40px;
+  scroll-margin-top: 88px;
+}
+.prose p { color: var(--fg); }
+.prose a { text-decoration: underline; text-underline-offset: 3px; text-decoration-color: var(--border-strong); }
+.prose a:hover { text-decoration-color: var(--accent); }
+.prose strong { color: var(--fg); font-weight: 600; }
+.prose ul, .prose ol { padding-left: 24px; margin-top: 20px; }
+.prose li { margin-top: 10px; padding-left: 4px; }
+.prose li::marker { color: var(--accent); }
+.prose blockquote {
+  border-left: 2px solid var(--accent);
+  padding: 4px 0 4px 24px;
+  margin: 32px 0;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+.prose hr { border: none; border-top: 1px solid var(--border); margin: 48px 0; }
+
+/* Callout box inside articles */
+.callout {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--accent);
+  border-radius: var(--radius);
+  padding: 20px 24px;
+  margin: 32px 0;
+}
+.callout p { margin: 0; color: var(--fg-muted); }
+.callout strong { color: var(--fg); }
+
+/* Key-takeaways / TL;DR */
+.takeaways {
+  background: linear-gradient(180deg, var(--accent-soft), transparent 60%), var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  margin: 8px 0 40px;
+}
+.takeaways h2 { font-size: 0.8rem !important; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin: 0 0 14px !important; padding: 0 !important; }
+.takeaways ul { margin: 0; padding-left: 22px; }
+.takeaways li { margin-top: 8px; color: var(--fg-muted); }
+
+/* Article table */
+.prose .table-wrap { overflow-x: auto; margin: 32px 0; }
+.prose table { width: 100%; border-collapse: collapse; font-size: 0.92rem; }
+.prose th, .prose td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--border); }
+.prose th { font-weight: 600; color: var(--fg); border-bottom: 1px solid var(--border-strong); }
+.prose td { color: var(--fg-muted); }
+
+/* Author / bio box */
+.author-box {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  margin-top: 56px;
+}
+.author-box img {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--border-strong);
+  flex-shrink: 0;
+}
+.author-box .author-name { font-weight: 600; }
+.author-box .author-role { font-size: 0.85rem; color: var(--fg-muted); margin: 4px 0 10px; }
+
+/* Breadcrumbs */
+.breadcrumbs {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--fg-dim);
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.breadcrumbs a { color: var(--fg-muted); }
+.breadcrumbs a:hover { color: var(--accent); }
+
+/* Inline CTA strip */
+.cta-strip {
+  text-align: center;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 40px 32px;
+  margin: 56px 0 8px;
+}
+
+@media (max-width: 600px) {
+  .article, .article-header { padding-left: 20px; padding-right: 20px; }
+  .author-box { flex-direction: column; gap: 16px; }
+}


### PR DESCRIPTION
Realizacja rekomendacji z audytu (Zadania E i G) — sekcja /blog/, która wcześniej zwracała 404:

- /blog/ — strona listy artykułów z wyróżnionym wpisem i siatką kart
- 5 artykułów po polsku:
  - NIS2 dla MŚP — checklista 90 dni (3000+ słów, artykuł flagowy)
  - Ile kosztuje wdrożenie AI w firmie B2B
  - n8n vs Zapier — automatyzacja dla firm
  - Lokalne modele LLM dla firm
  - 7 zastosowań agentów AI w firmie
- BlogLayout.astro + BlogCover.astro + src/data/blog-posts.js (źródło prawdy)
- Schema.org: Blog, BlogPosting i BreadcrumbList na każdej stronie (E-E-A-T)
- Linki wychodzące do autorytatywnych źródeł (ENISA, gov.pl, EUR-Lex, CERT/CSIRT) — Zadanie H
- Zdjęcie autora (alt) + dekoracyjne grafiki SVG w artykułach — Zadanie F
- Link "Blog" w nawigacji i stopce wszystkich podstron
- Aktualizacja sitemap.xml o /blog/ i 5 wpisów
- Style .prose, karty bloga, callouty, tabele w styles.css


Claude-Session: https://claude.ai/code/session_015DVaJGChv7Z5aZd56Ao9uJ