### PR TITLE
Dodanie 2 artykułów: ChatGPT a RODO oraz kontrola eksportu modeli AI

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -26,9 +26,21 @@
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/blog/</loc>
-    <lastmod>2026-06-16</lastmod>
+    <lastmod>2026-06-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/kontrola-eksportu-modeli-ai-szansa-dla-chin/</loc>
+    <lastmod>2026-06-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://brightmindsolutions.pl/blog/chatgpt-a-rodo-obsluga-klienta/</loc>
+    <lastmod>2026-06-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://brightmindsolutions.pl/blog/nis2-dla-msp-checklista-90-dni/</loc>

--- a/src/components/BlogCover.astro
+++ b/src/components/BlogCover.astro
@@ -20,3 +20,9 @@ const s = size;
 {hue === 'bot' && (
   <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="8" width="18" height="12" rx="2"/><path d="M12 8V4M8 4h8"/><circle cx="9" cy="14" r="1"/><circle cx="15" cy="14" r="1"/></svg>
 )}
+{hue === 'scale' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v18"/><path d="M5 7h14"/><path d="M5 7l-3 7a4 4 0 008 0L7 7"/><path d="M19 7l-3 7a4 4 0 008 0L21 7"/><path d="M7 21h10"/></svg>
+)}
+{hue === 'globe' && (
+  <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 010 18 14 14 0 010-18z"/></svg>
+)}

--- a/src/data/blog-posts.js
+++ b/src/data/blog-posts.js
@@ -16,6 +16,36 @@ export const author = {
 // Kolejność w tablicy = kolejność wyświetlania na liście bloga (najnowsze pierwsze).
 export const posts = [
   {
+    slug: 'kontrola-eksportu-modeli-ai-szansa-dla-chin',
+    title: 'Kontrola eksportu modeli AI: jak USA mogą oddać przewagę Chinom',
+    description:
+      'Kontrola eksportu modeli AI w USA: Fable 5 i GPT-5.6 pod restrykcjami w 2026. Dlaczego może na tym zyskać Chiny i co to znaczy dla Twojej firmy.',
+    excerpt:
+      'W czerwcu 2026 rząd USA dwukrotnie w dwa tygodnie ograniczył dostęp do czołowych modeli AI. Restrykcje pomyślane jako ochrona przewagi mogą ją przyspieszyć w stronę chińskich laboratoriów — i zmieniają kalkulację firm wdrażających AI.',
+    category: 'Rynek AI',
+    date: '2026-06-26',
+    dateModified: '2026-06-26',
+    readingTime: 9,
+    keywords:
+      'kontrola eksportu modeli AI, restrykcje eksportowe AI, GPT-5.6, modele AI Chiny, GLM-5.2, wdrożenie AI w firmie',
+    cover: { hue: 'globe', label: 'Rynek AI' },
+  },
+  {
+    slug: 'chatgpt-a-rodo-obsluga-klienta',
+    title: 'ChatGPT a RODO: czy mała firma może legalnie używać AI do obsługi klienta?',
+    description:
+      'Czy mała firma może używać ChatGPT do obsługi klienta zgodnie z RODO? Sprawdź zasady, ryzyka i bezpieczne wdrożenie AI krok po kroku.',
+    excerpt:
+      'Obsługa klienta prawie zawsze oznacza przetwarzanie danych osobowych, a to wprost podlega RODO. Wyjaśniam, kiedy użycie ChatGPT jest legalne, a kiedy naraża firmę na karę — i jak wdrożyć AI zgodnie z prawem.',
+    category: 'AI i Prawo',
+    date: '2026-06-23',
+    dateModified: '2026-06-23',
+    readingTime: 8,
+    keywords:
+      'ChatGPT a RODO, AI w obsłudze klienta, RODO a sztuczna inteligencja, dane osobowe w ChatGPT, umowa powierzenia przetwarzania, AI w małej firmie',
+    cover: { hue: 'scale', label: 'AI i Prawo' },
+  },
+  {
     slug: 'nis2-dla-msp-checklista-90-dni',
     title: 'NIS2 dla MŚP — checklista wdrożenia w 90 dni',
     description:

--- a/src/pages/blog/chatgpt-a-rodo-obsluga-klienta.astro
+++ b/src/pages/blog/chatgpt-a-rodo-obsluga-klienta.astro
@@ -1,0 +1,68 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="chatgpt-a-rodo-obsluga-klienta">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <p>Mała firma może używać ChatGPT do obsługi klienta zgodnie z RODO, ale tylko pod warunkiem, że nie wprowadza do darmowej wersji danych osobowych klientów, korzysta z wersji biznesowej z umową powierzenia, informuje klientów o przetwarzaniu i ogranicza zakres danych do niezbędnego minimum.</p>
+  </div>
+
+  <p>ChatGPT w obsłudze klienta to dziś realna oszczędność czasu — odpowiada na maile, redaguje pisma, podpowiada rozwiązania. Problem w tym, że obsługa klienta prawie zawsze oznacza przetwarzanie danych osobowych, a to wprost podlega RODO. Poniżej wyjaśniam, kiedy takie użycie jest legalne, a kiedy naraża firmę na karę.</p>
+
+  <h2>Czy wpisanie danych klienta do ChatGPT to przetwarzanie danych osobowych?</h2>
+
+  <p>Tak. Z punktu widzenia RODO każde wprowadzenie imienia, adresu, numeru zamówienia powiązanego z osobą czy treści reklamacji do narzędzia AI jest przetwarzaniem danych osobowych. Nie ma znaczenia, że robi to „tylko” pracownik w okienku czatu — odpowiedzialność jako administrator danych ponosi firma.</p>
+
+  <p>Kluczowa różnica dotyczy tego, <em>gdzie</em> te dane trafiają. W darmowej wersji ChatGPT dane mogą być wykorzystywane do trenowania modelu, a serwery znajdują się poza Europejskim Obszarem Gospodarczym. To dwa osobne problemy prawne naraz: brak kontroli nad dalszym wykorzystaniem danych i transfer poza EOG.</p>
+
+  <h2>Darmowy ChatGPT vs wersja biznesowa — co wolno?</h2>
+
+  <p>Dla obsługi klienta z danymi osobowymi darmowa wersja konsumencka jest ryzykowna. Bezpieczniejsza jest wersja biznesowa (ChatGPT Enterprise lub Team, albo dostęp przez API), która daje trzy rzeczy istotne dla RODO:</p>
+
+  <ul>
+    <li><strong>Umowa powierzenia przetwarzania (DPA)</strong> — formalna podstawa, by dostawca przetwarzał dane w imieniu firmy.</li>
+    <li><strong>Wyłączenie danych z treningu modelu</strong> — Twoje dane nie zasilają kolejnych wersji AI.</li>
+    <li><strong>Mechanizmy transferu danych</strong> poza EOG zgodne z prawem (standardowe klauzule umowne).</li>
+  </ul>
+
+  <p>Bez tych elementów firma w praktyce nie jest w stanie wykazać zgodności, a obowiązek wykazania (zasada rozliczalności) leży po jej stronie. Warunki przetwarzania danych w wersjach biznesowych opisuje dokumentacja dostawcy — m.in. <a href="https://openai.com/enterprise-privacy/" target="_blank" rel="noopener noreferrer">OpenAI Enterprise Privacy</a> — a ogólne zasady ochrony danych znajdziesz na stronie <a href="https://uodo.gov.pl/" target="_blank" rel="noopener noreferrer">Urzędu Ochrony Danych Osobowych</a>.</p>
+
+  <h2>Jak używać ChatGPT w obsłudze klienta zgodnie z RODO?</h2>
+
+  <p>Najprostsza i najbezpieczniejsza zasada brzmi: minimalizuj dane. Zanim wkleisz treść do AI, usuń lub zastąp dane identyfikujące — zamiast „Reklamacja Jana Kowalskiego, ul. Lipowa 4” wpisz „Reklamacja klienta dotycząca opóźnionej dostawy”. Model i tak pomoże zredagować odpowiedź, a Ty nie przekazujesz danych osobowych w ogóle.</p>
+
+  <p>Praktyczne minimum dla małej firmy:</p>
+
+  <ul>
+    <li>Korzystaj z wersji biznesowej z podpisaną umową powierzenia.</li>
+    <li>Nie wprowadzaj danych wrażliwych (zdrowie, dane finansowe szczegółowe) do narzędzia.</li>
+    <li>Zaktualizuj politykę prywatności i informację dla klientów o wykorzystaniu AI.</li>
+    <li>Przeszkol pracowników, co wolno wkleić, a czego nie.</li>
+    <li>Prowadź to w rejestrze czynności przetwarzania.</li>
+  </ul>
+
+  <div class="callout">
+    <p>Jeśli przetwarzasz dane szczególnie wrażliwe, rozważ rozwiązanie, w którym AI w ogóle nie wynosi informacji poza firmę — o tym, kiedy opłaca się <a href="/blog/lokalne-llm-dla-firm/">lokalny model LLM zamiast chmury</a>, piszę w osobnym artykule. Jeśli chcesz wdrożyć AI w obsłudze klienta tak, by od początku było zgodne z RODO, BrightMind pomaga ułożyć ten proces od strony prawnej i technicznej jednocześnie — <a href="/#kontakt">umów bezpłatną konsultację</a>.</p>
+  </div>
+
+  <h2>Najczęstsze pytania</h2>
+
+  <h3>Czy mogę dostać karę za używanie ChatGPT bez zgody klienta?</h3>
+  <p>Tak, jeśli przetwarzasz dane osobowe bez podstawy prawnej, bez umowy powierzenia z dostawcą lub bez poinformowania klientów. Kary RODO sięgają do 20 mln euro lub 4% rocznego obrotu, choć dla MŚP w praktyce są znacznie niższe i zależą od skali naruszenia.</p>
+
+  <h3>Czy wystarczy zgoda klienta na używanie AI?</h3>
+  <p>Zgoda nie jest tu zwykle najlepszą podstawą — częściej przetwarzanie opiera się na wykonaniu umowy lub uzasadnionym interesie. Ważniejsze od „zgody na AI” jest poinformowanie klienta i zapewnienie umowy powierzenia z dostawcą narzędzia.</p>
+
+  <h3>Czy darmowy ChatGPT da się w ogóle legalnie wykorzystać w firmie?</h3>
+  <p>Tak — do zadań, które nie dotykają danych osobowych: pisanie ofert, szablonów, treści marketingowych, burza mózgów. Granica przebiega tam, gdzie pojawiają się dane konkretnego, możliwego do zidentyfikowania klienta.</p>
+
+  <h3>Czy muszę zgłaszać używanie AI do UODO?</h3>
+  <p>Samego używania narzędzia nie zgłasza się do UODO. Może być natomiast konieczna ocena skutków dla ochrony danych (DPIA), jeśli przetwarzanie z użyciem AI niesie wysokie ryzyko dla praw klientów.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> ChatGPT w obsłudze klienta jest zgodny z RODO, jeśli zadbasz o cztery rzeczy: wersję biznesową z umową powierzenia, minimalizację danych, poinformowanie klientów i przeszkolony zespół. Chcesz wdrożyć AI w obsłudze klienta bez ryzyka prawnego? <a href="/#kontakt">Umów bezpłatną konsultację</a> — ułożymy proces zgodny z RODO od strony prawnej i technicznej.</p>
+
+</BlogLayout>

--- a/src/pages/blog/kontrola-eksportu-modeli-ai-szansa-dla-chin.astro
+++ b/src/pages/blog/kontrola-eksportu-modeli-ai-szansa-dla-chin.astro
@@ -1,0 +1,70 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+---
+
+<BlogLayout slug="kontrola-eksportu-modeli-ai-szansa-dla-chin">
+
+  <div class="takeaways">
+    <h2>W skrócie</h2>
+    <p>W czerwcu 2026 roku rząd USA w ciągu dwóch tygodni dwukrotnie ograniczył dostęp do czołowych amerykańskich modeli AI — najpierw kontrolą eksportową na modele Anthropic (Fable 5 i Mythos 5), potem prośbą do OpenAI o etapowe udostępnianie GPT-5.6. Powodem w obu przypadkach były zaawansowane zdolności w obszarze cyberbezpieczeństwa. Paradoks polega na tym, że restrykcje pomyślane jako ochrona przewagi technologicznej mogą tę przewagę przyspieszyć w stronę chińskich laboratoriów.</p>
+  </div>
+
+  <p>Kontrola eksportu modeli AI przestała być teoretycznym scenariuszem. W czerwcu 2026 roku administracja Donalda Trumpa dwukrotnie w ciągu dwóch tygodni ograniczyła publiczny dostęp do najnowszych modeli amerykańskich laboratoriów. Dla firm, które planują wdrożenia oparte na frontier AI, to nie ciekawostka geopolityczna, lecz realne ryzyko: model, na którym chcesz zbudować proces, może nie być dostępny wtedy, kiedy go potrzebujesz.</p>
+
+  <h2>Co dokładnie się wydarzyło w czerwcu 2026?</h2>
+
+  <p>W ciągu dwóch tygodni rząd USA dwa razy ograniczył dostęp do czołowych modeli — za każdym razem inaczej i z innego źródła. 12 czerwca 2026 Departament Handlu wydał dyrektywę o kontroli eksportowej wobec Anthropic, w wyniku której firma musiała wycofać z publicznego dostępu swoje najnowsze modele Fable 5 i Mythos 5. Powodem były obawy o ich zdolności w obszarze cyberbezpieczeństwa i ryzyko dostępu zagranicznych podmiotów.</p>
+
+  <p>Niespełna dwa tygodnie później, 25 czerwca, ujawniono drugą sprawę. Tym razem nie była to formalna kontrola eksportowa, lecz prośba Białego Domu skierowana do OpenAI, by najnowszy model GPT-5.6 trafił najpierw wyłącznie do wąskiej grupy zatwierdzonych klientów biznesowych. Dostęp każdego z nich administracja ma zatwierdzać — według wewnętrznego memo Sama Altmana — „klient po kliencie”. Szerszy rollout ma nastąpić dopiero po okresie preview, jeśli rządowy proces zatwierdzania przebiegnie pomyślnie.</p>
+
+  <p>Warto rozróżnić te dwa mechanizmy, bo bywają mylone. W przypadku Anthropic mówimy o kontroli eksportowej z Departamentu Handlu. W przypadku OpenAI — o prośbie dwóch agencji: Office of the National Cyber Director oraz Office of Science and Technology Policy. Wspólny mianownik jest jeden: model uznano za zbyt zaawansowany w zdolnościach ofensywnych, by udostępnić go publicznie bez nadzoru.</p>
+
+  <h2>Dlaczego rząd USA ogranicza własne modele AI?</h2>
+
+  <p>Powodem są zdolności tych modeli w cyberbezpieczeństwie, które według administracji osiągnęły poziom zagrażający bezpieczeństwu narodowemu. Zarówno OpenAI, jak i rząd oceniają GPT-5.6 jako porównywalny z modelem Mythos od Anthropic — a to właśnie ta klasa zaawansowania uruchomiła interwencję.</p>
+
+  <p>Kluczowy problem leży gdzie indziej. W USA nie istnieje dziś spójne ramy prawne regulujące przedpremierowy przegląd zaawansowanych modeli AI. Trump podpisał wprawdzie w czerwcu rozporządzenie wykonawcze zachęcające laboratoria do dobrowolnego przekazywania modeli rządowi do oceny na 30 dni przed premierą, ale procedura tej oceny wciąż nie powstała. W efekcie mamy działanie ad hoc — raz przez Departament Handlu, raz przez Biały Dom, bez jednego, przejrzystego trybu. Sam Altman w memo do pracowników napisał wprost, że obecny model współpracy nie jest docelowy i firma będzie szukać bardziej zrównoważonego podejścia.</p>
+
+  <h2>Kto zyskuje na restrykcjach eksportowych — Chiny</h2>
+
+  <p>Na ograniczaniu dostępu do amerykańskich modeli najbardziej skorzystać mogą chińskie laboratoria. Jeśli czołowe modele z USA będą trafiać na rynek z opóźnieniem i pod kontrolą, a chińskie laboratoria publikują bez takich hamulców, asymetria tempa zaczyna działać na korzyść Pekinu.</p>
+
+  <p>To nie jest abstrakcja. Największe chińskie modele już dziś dorównują najlepszym amerykańskim — GLM-5.2 jest tego przykładem. Kolejne iteracje DeepSeeka, Qwena i GLM mają przed sobą wolne pole, jeśli amerykańska konkurencja sama zwolni własne tempo wdrożeń. I tu tkwi paradoks: restrykcje pomyślane jako ochrona przewagi technologicznej mogą tę przewagę oddać — nie dlatego, że Chiny dokonają technologicznego przeskoku, ale dlatego, że Zachód spowolni dystrybucję własnych narzędzi.</p>
+
+  <h2>Co to oznacza dla polskich firm wdrażających AI?</h2>
+
+  <p>Dla firmy planującej wdrożenie AI płynie z tego jeden praktyczny wniosek: dostępność konkretnego modelu przestaje być pewnikiem. Strategia oparta na jednym dostawcy frontier AI staje się ryzykowna, jeśli ten dostawca może z dnia na dzień zostać objęty restrykcją regulacyjną w swoim kraju.</p>
+
+  <p>Rozsądne podejście to:</p>
+
+  <ul>
+    <li>Projektowanie procesów tak, by były przenośne między modelami, zamiast twardego przywiązania do jednego API.</li>
+    <li>Realna ocena, czy dany proces faktycznie wymaga najnowszego frontier modelu, czy wystarczy stabilniejszy, szeroko dostępny model starszej generacji.</li>
+    <li>Świadome śledzenie dostępności i statusu prawnego modeli — także tych spoza USA, które mogą okazać się zarówno alternatywą, jak i źródłem własnych pytań o zgodność z RODO i bezpieczeństwo danych.</li>
+  </ul>
+
+  <p>Z perspektywy łączącej prawo cyfrowe i wdrożenia AI ta ostatnia kwestia jest najważniejsza. Wybór chińskiego modelu jako alternatywy dla niedostępnego modelu amerykańskiego to nie tylko decyzja techniczna — to decyzja o tym, gdzie i pod jakim reżimem prawnym przetwarzane są dane Twojej firmy. Dostępność i zgodność to dwie różne rzeczy, a w 2026 roku trzeba patrzeć na obie naraz.</p>
+
+  <div class="callout">
+    <p>Jednym ze sposobów na uniezależnienie się od zawirowań wokół dostępu do modeli chmurowych jest oparcie wrażliwych procesów o <a href="/blog/lokalne-llm-dla-firm/">lokalne modele LLM</a>, które działają na infrastrukturze firmy. Jeśli zastanawiasz się, jak zbudować strategię wdrożenia AI odporną na takie zmiany regulacyjne, BrightMind pomaga przejść przez ten proces od strony technicznej i prawnej — <a href="/#kontakt">umów bezpłatną konsultację</a>.</p>
+  </div>
+
+  <h2>Najczęstsze pytania</h2>
+
+  <h3>Czy USA wprowadziły kontrolę eksportową na GPT-5.6?</h3>
+  <p>Nie w sensie formalnym. GPT-5.6 objęła prośba Białego Domu o etapowe udostępnianie wąskiej grupie zatwierdzonych klientów, a nie dyrektywa eksportowa. Formalną kontrolę eksportową z Departamentu Handlu objęto natomiast modele Anthropic — Fable 5 i Mythos 5 — w czerwcu 2026.</p>
+
+  <h3>Dlaczego te modele uznano za niebezpieczne?</h3>
+  <p>Powodem były ich zaawansowane zdolności w obszarze cyberbezpieczeństwa, ocenione jako potencjalnie zagrażające bezpieczeństwu narodowemu. Administracja chciała mieć pewność, że laboratoria mają odpowiednie zabezpieczenia, zanim modele trafią do szerokiego obiegu.</p>
+
+  <h3>Czy chińskie modele AI naprawdę dorównują amerykańskim?</h3>
+  <p>Najlepsze chińskie modele, jak GLM-5.2, są już porównywalne z czołowymi modelami amerykańskimi. Tempo kolejnych iteracji DeepSeeka, Qwena i GLM sprawia, że luka, która jeszcze niedawno była wyraźna, szybko się zamyka.</p>
+
+  <h3>Co powinna zrobić firma planująca wdrożenie AI w tej sytuacji?</h3>
+  <p>Unikać twardego przywiązania do jednego dostawcy frontier AI, projektować procesy przenośne między modelami i osobno oceniać dostępność oraz zgodność prawną wybranego modelu — zwłaszcza przy modelach spoza UE i USA.</p>
+
+  <hr />
+
+  <p><strong>Podsumowanie.</strong> Kontrola eksportu modeli AI pokazała, że dostępność czołowych modeli bywa kwestią decyzji regulacyjnej, a nie tylko technologii. Dla firm oznacza to jedno: buduj wdrożenia odporne na zmianę dostawcy i patrz równolegle na dostępność oraz zgodność prawną. <a href="/#kontakt">Umów bezpłatną konsultację</a> — pomożemy zaprojektować strategię AI, która przetrwa kolejne zawirowania na rynku.</p>
+
+</BlogLayout>


### PR DESCRIPTION
- ChatGPT a RODO: czy mała firma może legalnie używać AI do obsługi klienta (kategoria: AI i Prawo)
- Kontrola eksportu modeli AI: jak USA mogą oddać przewagę Chinom (kategoria: Rynek AI)
- Nowe ikony okładek SVG: scale (prawo) i globe (geopolityka)
- Schema.org BlogPosting + BreadcrumbList, linki wewnętrzne i wychodzące
- Wpisy dodane do sitemap.xml i listy /blog/ (jako najnowsze)


Claude-Session: https://claude.ai/code/session_015DVaJGChv7Z5aZd56Ao9uJ